### PR TITLE
Simplified BMI implementation with var_info array of struct

### DIFF
--- a/include/bmi_topmodel.h
+++ b/include/bmi_topmodel.h
@@ -8,6 +8,19 @@ extern "C" {
 #include "bmi.h"
 #include "topmodel.h"
 
+//--------------------------------------------
+// Used to simplify BMI implementation (SDP)
+//--------------------------------------------
+typedef struct Variable{
+    unsigned int index;
+    char name[80];
+    char type[80];
+    unsigned int size;
+    // char units[80];
+    // char role[80];
+    // bool is_pointer;
+} Variable;
+
 Bmi* register_bmi_topmodel(Bmi *model);
 
 topmodel_model * new_bmi_topmodel();

--- a/test_serialize/README.md
+++ b/test_serialize/README.md
@@ -59,8 +59,8 @@ along with a small shell script called
 
 **Note:** In ```serialize_state.c```, there are constants called
 ```BUFFER_SIZE``` and ```UNPACKED_BUFFER_SIZE``` that must be big
-enough to accommodate all state variables.  If the model's nsteps
-is increased, these constants may also need to be increased.
+enough to accommodate all state variables.  These are now set
+dynamically using the filesize of the serialized state.
 
 **Note:** To print and inspect the values of all state variables after
 they have been deserialized (usually from a file), you should change the

--- a/test_serialize/serialize_state.c
+++ b/test_serialize/serialize_state.c
@@ -416,8 +416,9 @@ int deserialize_to_state(const char *ser_file, Bmi* model2, int print_obj) {
 
         if (size == 1){
             //--------------------------------------------
-            // Note:  This does not work, even though we
-            //        typecast in set_state_var().
+            // Note: The 2 lines commented here do not
+            //       work, even though we typecast in
+            //       set_state_var().
             //--------------------------------------------
             // ptr = &obj;
             // model2->set_state_var(model2, ptr, i );
@@ -426,7 +427,7 @@ int deserialize_to_state(const char *ser_file, Bmi* model2, int print_obj) {
                 i_val = (int)obj.via.i64;
                 model2->set_state_var(model2, &i_val, i );
             } else if (strcmp(type, "long") == 0){        
-                li_val = (int)obj.via.i64;
+                li_val = (long)obj.via.i64;
                 model2->set_state_var(model2, &li_val, i );
             } else if (strcmp(type, "float") == 0){        
                 f_val = (float)obj.via.f64;

--- a/test_serialize/serialize_state.c
+++ b/test_serialize/serialize_state.c
@@ -269,7 +269,7 @@ int serialize(Bmi* model1, const char *ser_file) {
             } else if (strcmp(type, "long") == 0){
                 for (j=0; j<size; j++){
                     li_val = *( ((long *)ptr_list[i]) + j);
-                    msgpack_pack_long(&pk, li_val); }    //#####################
+                    msgpack_pack_long(&pk, li_val); }    //##############
             } else if (strcmp(type, "float") == 0){
                 for (j=0; j<size; j++){
                     f_val = *( ((float *)ptr_list[i]) + j);

--- a/test_serialize/topmodel_serialize_test.c
+++ b/test_serialize/topmodel_serialize_test.c
@@ -57,7 +57,7 @@ int print_some(void *ptr_list[]){
   printf("ptr_list[50] = cur_tstep = %d\n", *(int *)ptr_list[50]);
   printf("ptr_list[51] = sump   = %f\n", *(double *)ptr_list[51]);
   printf("ptr_list[53] = sumq   = %f\n", *(double *)ptr_list[53]);
-  //printf("ptr_list[56] = dbl_arr_test = %f, %f, %f\n", a[0], a[1], a[2]);
+  printf("ptr_list[56] = dbl_arr_test = %f, %f, %f\n", a[0], a[1], a[2]);
   puts("");    // newline is added
 
   return 0;

--- a/test_serialize/topmodel_serialize_test.c
+++ b/test_serialize/topmodel_serialize_test.c
@@ -41,13 +41,17 @@ int print_some(void *ptr_list[]){
   //       Careful with order of operations.
   //------------------------------------------------
   puts("Printing some selected variables ...");
-  double a[3];
-  a[0] = *( (double *)ptr_list[56]);
-  a[1] = *( (double *)ptr_list[56] + 1);
-  a[2] = *( (double *)ptr_list[56] + 2);
+
+  //--------------------------------------------  
+  // Only used for the "dbl_arr_test" variable
+  //--------------------------------------------
+  // double a[3];
+  // a[0] = *( (double *)ptr_list[62]);
+  // a[1] = *( (double *)ptr_list[62] + 1);
+  // a[2] = *( (double *)ptr_list[62] + 2);
   
-  // a[1] = *(double *)(ptr_list[56] + 1);  // This is wrong.
-  // a[2] = *(double *)(ptr_list[56] + 2);
+  // // a[1] = *(double *)(ptr_list[62] + 1);  // This is wrong.
+  // // a[2] = *(double *)(ptr_list[62] + 2);
   
   printf("ptr_list[6]  = title  = %s", ptr_list[6]);   
   printf("ptr_list[8]  = dt     = %f\n", *(double *)ptr_list[8]);
@@ -56,13 +60,16 @@ int print_some(void *ptr_list[]){
   printf("ptr_list[42] = lnaotb = %f\n", *(double *)ptr_list[42]);
   printf("ptr_list[50] = cur_tstep = %d\n", *(int *)ptr_list[50]);
   printf("ptr_list[51] = sump   = %f\n", *(double *)ptr_list[51]);
+  printf("ptr_list[52] = sumae  = %f\n", *(double *)ptr_list[52]);
   printf("ptr_list[53] = sumq   = %f\n", *(double *)ptr_list[53]);
-  printf("ptr_list[56] = dbl_arr_test = %f, %f, %f\n", a[0], a[1], a[2]);
+  printf("ptr_list[54] = sumrz  = %f\n", *(double *)ptr_list[54]);
+  printf("ptr_list[55] = sumuz  = %f\n", *(double *)ptr_list[55]);  
+  // printf("ptr_list[62] = dbl_arr_test = %f, %f, %f\n", a[0], a[1], a[2]);
   puts("");    // newline is added
 
   return 0;
 }
-
+        
 //------------------------------------------------------------------------
 int main(void)
 {


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- 

## Removals

-

## Changes

- Started with latest version of master at:  github.com/NOAA-OWP/topmodel (62 vars now)
- Added Variable struct in bmi_topmodel.h
- Added var_info, array of Variable struct, in bmi_topmodel.c (to simplify BMI implementation)
- Added code in test_serialize/serialize_state.c to handle "long" variables.
- Updated information in test_serialize/README.md about BUFFER_SIZE.

## Testing

1. Successfully ran:  test_serialize/make_and_run_ser_test.sh.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
