### PR TITLE
Update `expinf()` function def

### DIFF
--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -50,7 +50,7 @@ extern void tread(FILE *subcat_fptr,FILE *output_fptr,char *subcat,
                 double **cum_dist_area_with_dist, double *tl, 
                 double **dist_from_outlet, int maxsubcatch, int maxincr);
                   
-extern void expinf(int irof, int it, int rint, double df, double cumf,
+extern void expinf(int irof, int it, int rint, double *df, double *cumf,
                 double dt,double xk0, double szm, double hf);                  
 
 extern void results(FILE *output_fptr, FILE *out_hyd_fptr,


### PR DESCRIPTION
`expinf()` subroutine calculates infiltration runoff based off bool flag `infex` set in data/params.dat and is called in primary model-run function `topmod()`. Fixes #23 
```
extern void expinf(int irof, int it, int rint, double *df, double *cumf,
                double dt,double xk0, double szm, double hf);     
```
## Changes
Variables `df` and `cumf` are now passed as pointers so values are being updated during each `bmi.update()` call.

 ## Testing
Model results as expected when `infex = 1`
Output hydrograph, `hyd.out` seems reasonable compared to when `infex = 0`

## Notes
The green-ampt depth model is not usually appropriate in catchments where topmodel is applicable (shallow highly permeable soils). I.e. it's likely that `infex` will always be `0`/`FALSE`