### PR TITLE
Results() function called in bmi.finalize()

### DIFF
--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -55,7 +55,7 @@ extern void expinf(int irof, int it, int rint, double *df, double *cumf,
 
 extern void results(FILE *output_fptr, FILE *out_hyd_fptr,
                 int nstep, double *Qobs, double *Q, 
-                int current_time_step, int yes_print_output);
+                int yes_print_output);
 
 extern void water_balance(FILE *output_fptr, int yes_print_output,
                 char *subcat, double *bal, double *sbar, double *sump,

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -366,6 +366,16 @@ static int Initialize (Bmi *self, const char *cfg_file)
     topmodel->sumae = 0.0;
     topmodel->sumq = 0.0;
 
+/*    irof=0;
+rex=0.0;
+cumf=0.0;
+max_contrib_area=0.0;
+sump=0.0;
+sumae=0.0;
+sumq=0.0;
+sae=0.0;*/
+
+
     return BMI_SUCCESS;
 }
 
@@ -401,22 +411,9 @@ static int Update (Bmi *self)
         &topmodel->sump,&topmodel->sumae,&topmodel->sumq,&topmodel->sumrz,&topmodel->sumuz,
         &topmodel->quz, &topmodel->qb, &topmodel->qof, &topmodel->p, &topmodel->ep );
 
-    //--------------------------------------------------
-    // This should be moved into the Finalize() method
-    //--------------------------------------------------
-    // results() 
-    // 1. generates hydrograph out file (hyd.out)
-    // 2. computes objective function stats
-    //        - print to console
-    //        - print to main out file (topmod.out)
-    // Logic for each is handled indiv w.i. funct,
-    // but wouldn't hurt to check conditions here as framework
-    // will likely not even need to jump into results()
-    if (topmodel->stand_alone == TRUE){
-    results(topmodel->output_fptr, topmodel->out_hyd_fptr, topmodel->nstep, 
-        topmodel->Qobs, topmodel->Q, 
-        topmodel->current_time_step, topmodel->yes_print_output);
-    }
+    if ((topmodel->stand_alone == FALSE) & (topmodel->yes_print_output == TRUE)){
+        fprintf(topmodel->out_hyd_fptr,"%d %lf %lf\n",topmodel->current_time_step,topmodel->Qobs[1],topmodel->Q[1]);
+    }      
 
     return BMI_SUCCESS;
 }
@@ -452,62 +449,67 @@ static int Update_until (Bmi *self, double t)
 
 static int Finalize (Bmi *self)
 {
-  if (self){
-    topmodel_model* model = (topmodel_model *)(self->data);
+    if (self){
+        topmodel_model* model = (topmodel_model *)(self->data);
 
-    //-----------------------------------------------------------
-    // When running in stand-alone mode, the original "results"
-    // method should be called here in the Finalize() method,
-    // not in Update_until(). It could also be called when in
-    // framework-controlled mode.
-    //-----------------------------------------------------------
-    //if (model->yes_print_output == TRUE || TOPMODEL_DEBUG >= 1){
-    //results(model->output_fptr,model->out_hyd_fptr,model->nstep, 
-    //    model->Qobs, model->Q, 
-    //    model->current_time_step, model->yes_print_output);
-    
-    if (model->yes_print_output == TRUE || TOPMODEL_DEBUG >= 1){        
+        if (model->yes_print_output == TRUE || TOPMODEL_DEBUG >= 1){        
+            
+            water_balance(model->output_fptr, model->yes_print_output,
+                model->subcat,&model->bal, &model->sbar, &model->sump, 
+                &model->sumae, &model->sumq, &model->sumrz, &model->sumuz);
+
+            // this is technically needed, yes
+            if(model->yes_print_output==TRUE){
+                fprintf(model->output_fptr,"Maximum contributing area %12.5lf\n",model->max_contrib_area);
+            }
+
+            //-----------------------------------------------------------
+            // When running in stand-alone mode, the original "results"
+            // method should be called here in the Finalize() method,
+            // not in Update_until(). It could also be called when in
+            // framework-controlled mode.
+            //-----------------------------------------------------------
+            if (model->stand_alone == TRUE){
+                results(model->output_fptr,model->out_hyd_fptr,model->nstep, 
+                model->Qobs, model->Q, model->yes_print_output);                 
+            }
+        }    
+
+        if( model->Q != NULL )
+            free(model->Q);
+        if( model->Qobs != NULL )
+            free(model->Qobs);
+        if( model->rain != NULL )
+            free(model->rain);
+        if( model->pe != NULL )
+            free(model->pe);
+        if( model->contrib_area != NULL )
+            free(model->contrib_area);
+        if( model->stor_unsat_zone != NULL )
+            free(model->stor_unsat_zone);
+        if( model->deficit_root_zone != NULL )
+            free(model->deficit_root_zone);
+        if( model->deficit_local != NULL )
+            free(model->deficit_local);
+        if( model->time_delay_histogram != NULL )
+            free(model->time_delay_histogram);
+        if( model->dist_area_lnaotb != NULL )
+            free(model->dist_area_lnaotb);
+        if( model->lnaotb != NULL )
+            free(model->lnaotb);
+        if( model->cum_dist_area_with_dist != NULL )
+            free(model->cum_dist_area_with_dist);
+        if( model->dist_from_outlet != NULL)
+            free(model->dist_from_outlet);
+
+        // Close output files only if opened in first place
+        if(model->yes_print_output == TRUE){
+            fclose(model->output_fptr);
+            fclose(model->out_hyd_fptr);
+        }
         
-        water_balance(model->output_fptr, model->yes_print_output,
-            model->subcat,&model->bal, &model->sbar, &model->sump, 
-            &model->sumae, &model->sumq, &model->sumrz, &model->sumuz);
+        free(self->data);
     }
-
-    if( model->Q != NULL )
-        free(model->Q);
-    if( model->Qobs != NULL )
-        free(model->Qobs);
-    if( model->rain != NULL )
-        free(model->rain);
-    if( model->pe != NULL )
-        free(model->pe);
-    if( model->contrib_area != NULL )
-        free(model->contrib_area);
-    if( model->stor_unsat_zone != NULL )
-        free(model->stor_unsat_zone);
-    if( model->deficit_root_zone != NULL )
-        free(model->deficit_root_zone);
-    if( model->deficit_local != NULL )
-        free(model->deficit_local);
-    if( model->time_delay_histogram != NULL )
-        free(model->time_delay_histogram);
-    if( model->dist_area_lnaotb != NULL )
-        free(model->dist_area_lnaotb);
-    if( model->lnaotb != NULL )
-        free(model->lnaotb);
-    if( model->cum_dist_area_with_dist != NULL )
-        free(model->cum_dist_area_with_dist);
-    if( model->dist_from_outlet != NULL)
-        free(model->dist_from_outlet);
-
-    // Close output files only if opened in first place
-    if(model->yes_print_output == TRUE){
-        fclose(model->output_fptr);
-        fclose(model->out_hyd_fptr);
-    }
-    
-    free(self->data);
-  }
     return BMI_SUCCESS;
 }
 

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -340,36 +340,6 @@ for(ia=1;ia<=num_topodex_values;ia++)
 
   }
 
-//(*bal)+=(*sbar)+(*sump)-(*sumae)-(*sumq)+(*sumrz)-(*sumuz);
-// TODO: Confirm these values are correct outside of initial value (validated-okay) 
-// and final (validated-okay)
-
-/*  BMI Adaption: Compute and print summary summations only at end of model run */
-/*  TODO: Find and replace line string in out file for any current_time_step? */
-/*if (current_time_step == 100)
-  {
-
-  //(*bal)+=(*sbar)+(*sump)-(*sumae)-(*sumq)+(*sumrz)-(*sumuz);
-
-#if TOPMODEL_DEBUG >=1  
-  printf("\nWater Balance for Subcatchment: %s\n",subcat);
-  printf(
-  "   SUMP       SUMAE      SUMQ       SUMRZ      SUMUZ      SBAR        BAL\n");
-  printf("%6.3e  %6.3e  %6.3e  %6.3e  %6.3e  %6.3e  %6.3e\n",
-          (*sump),(*sumae),(*sumq),(*sumrz),(*sumuz),(*sbar),(*bal));
-#endif
-
-  if (yes_print_output==TRUE)
-    {
-    fprintf(output_fptr,"\nWater Balance for Subcatchment: %s\n",subcat);
-    fprintf(output_fptr,
-    "   SUMP       SUMAE      SUMQ       SUMRZ      SUMUZ      SBAR        BAL\n");
-    fprintf(output_fptr,"%6.3e  %6.3e  %6.3e  %6.3e  %6.3e  %6.3e  %6.3e\n",
-           (*sump),(*sumae),(*sumq),(*sumrz),(*sumuz),(*sbar),(*bal));
-    fprintf(output_fptr,"Maximum contributing area %12.5lf\n",max_contrib_area);
-    }
-  }*/
-
 return;
 
 }
@@ -396,7 +366,6 @@ extern void water_balance(FILE *output_fptr, int yes_print_output,
     "   SUMP       SUMAE      SUMQ       SUMRZ      SUMUZ      SBAR        BAL\n");
     fprintf(output_fptr,"%6.3e  %6.3e  %6.3e  %6.3e  %6.3e  %6.3e  %6.3e\n",
            (*sump),(*sumae),(*sumq),(*sumrz),(*sumuz),(*sbar),(*bal));
-    //fprintf(output_fptr,"Maximum contributing area %12.5lf\n",max_contrib_area);
     }
 
 return;
@@ -835,7 +804,7 @@ return;
 
 extern void results(FILE *output_fptr, FILE *out_hyd_fptr,
                  int nstep, double *Qobs, double *Q, 
-                 int current_time_step, int yes_print_output )
+                 int yes_print_output)
 {
 /***************************************************************
       SUBROUTINE RESULTS
@@ -844,41 +813,29 @@ extern void results(FILE *output_fptr, FILE *out_hyd_fptr,
   AND DOES OBJECTIVE FUNCTION CALCULATIONS 
   *************************************************************/
 
-/* BMI Adaption: include current_time_step yes_print_output as function input parameter*/
+/* BMI Adaption: include additional function input parameters:
+    yes_print_output
+*/
   
-double f1,f2,sumq,ssq,vare,varq,qbar,nse;
-int it;
-
-/* BMI Adaption: Set initial values for intital time step only */
-if (current_time_step == 1){
+  double f1,f2,sumq,ssq,vare,varq,qbar,nse;
+  int it;
   f1=0.0;
   f2=0.0;
   sumq=0.0;
   ssq=0.0;
-}  
 
-/* BMI Adaption: Set iteration to current_time_step*/
-it = current_time_step;
-
-/* BMI Adaption: Apply yes_print_output to hyd.out too*/
-if (yes_print_output == TRUE){
-  fprintf(out_hyd_fptr,"%d %lf %lf\n",it,Qobs[it],Q[it]);  
-}
-
-/*  BMI Adaption: Compute and print summary summations only at end of model run */
-/*  TODO: Find and replace line string in out file for any current_time_step*/
-if (current_time_step == nstep) {
-
-  for(it=1;it<=current_time_step;it++)
-    {
+  for(it=1;it<=nstep;it++){
     sumq+=Qobs[it];
     ssq+=Qobs[it]*Qobs[it];
     f1+=pow((Q[it]-Qobs[it]),2.0);
     f2=f2 + fabs(Q[it]-Qobs[it]);
+    if (yes_print_output == TRUE){
+      fprintf(out_hyd_fptr,"%d %lf %lf\n",it,Qobs[it],Q[it]);
     }
-  qbar=sumq/(double)current_time_step;
-  varq=(ssq/(double)current_time_step -qbar*qbar);
-  vare=f1/(double)current_time_step;
+  }
+  qbar=sumq/(double)nstep;
+  varq=(ssq/(double)nstep -qbar*qbar);
+  vare=f1/(double)nstep;
   nse=1.0-vare/varq;
 
 /* BMI Adaption: Console prints based on macro setting*/
@@ -896,7 +853,6 @@ if (current_time_step == nstep) {
     fprintf(output_fptr,"Mean Obs Q %e   Variance Obs Q %e\n",qbar,varq);
     fprintf(output_fptr,"    Error Variance %e\n",vare);
   }
-};
 
 return;
 }


### PR DESCRIPTION
From `tmod9502.c`, the function `results()`: 
1. generates hydrograph out file (hyd.out)
2. computes objective function stats (based on Qobs)
   - print to console
   - print to main out file (topmod.out)

This should live in `bmi.finalize()` vs `bmi.update()`

## Changes
- `results()` def is basically identical to [source code](https://github.com/NOAA-OWP/topmodel/blob/4a1b861155038ee6a5a7d018bfa8ca95cb23afb7/refs/original_code_c/tmod9502.c#L949)
- `results()` now called in [`bmi.finalize()`](https://github.com/madMatchstick/topmodel/blob/a24db5a5ce68ff40bc747a7931f8545d8aacf14d/src/bmi_topmodel.c#L472) 
```
            if (model->stand_alone == TRUE){
                results(model->output_fptr,model->out_hyd_fptr,model->nstep, 
                model->Qobs, model->Q, model->yes_print_output);                 
            }
```
- Option to print hydrograph `hyd.out` still maintained when `stand_alone FALSE` in [`bmi.update()`](https://github.com/madMatchstick/topmodel/blob/a24db5a5ce68ff40bc747a7931f8545d8aacf14d/src/bmi_topmodel.c#L414)
```    
if ((topmodel->stand_alone == FALSE) & (topmodel->yes_print_output == TRUE)){
        fprintf(topmodel->out_hyd_fptr,"%d %lf %lf\n",topmodel->current_time_step,topmodel->Qobs[1],topmodel->Q[1]);
    }
``` 

## Additions
- `max_contrib_area` now back in `topmod.out` ; maintaining source code. See [`bmi.finalize()`](https://github.com/madMatchstick/topmodel/blob/a24db5a5ce68ff40bc747a7931f8545d8aacf14d/src/bmi_topmodel.c#L463).
```   
fprintf(model->output_fptr,"Maximum contributing area %12.5lf\n",model->max_contrib_area);
```
fixes issue #17 
## Testing

1. Primary MAKE file in /src


