### PR TITLE
Update BMI specification to include calibratable parameters

### DIFF
--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -6,6 +6,7 @@
 #define MAX_FILENAME_LENGTH 256
 #define OUTPUT_VAR_NAME_COUNT 14
 #define INPUT_VAR_NAME_COUNT 2
+#define PARAM_VAR_NAME_COUNT 5
   
 static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "Qout",
@@ -140,6 +141,22 @@ static const char input_var_grids[INPUT_VAR_NAME_COUNT] = {
 static const char *input_var_locations[INPUT_VAR_NAME_COUNT] = {
         "node",
         "node"
+};
+
+static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
+    "szm",   // exponential scaling parameter for the decline of transmissivity with increase in storage deficit (m)
+    "td",    // unsaturated zone time delay per unit storage deficit (h)
+    "srmax", // maximum root zone storage deficit (m)
+    "sr0",   // initial root zone storage deficit below field capacity (m)
+    "xk0"    // surface soil hydraulic conductivity (m/h)
+};
+
+static const char *param_var_types[PARAM_VAR_NAME_COUNT] = {
+    "double",
+    "double",
+    "double",
+    "double",
+    "double"
 };
 
 int read_init_config(const char* config_file, topmodel_model* model) {
@@ -532,6 +549,13 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
             return BMI_SUCCESS;
         }
     }
+    // Then check to see if in parameter array
+    for (int i = 0; i < PARAM_VAR_NAME_COUNT; i++) {
+        if (strcmp(name, param_var_names[i]) == 0) {
+            strncpy(type, param_var_types[i], BMI_MAX_TYPE_NAME);
+            return BMI_SUCCESS;
+        }
+    }
     // If we get here, it means the variable name wasn't recognized
     type[0] = '\0';
     return BMI_FAILURE;
@@ -770,6 +794,42 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         *dest = (void*)&topmodel-> bal;
         return BMI_SUCCESS;
     }
+    // szm (parameter)
+    if (strcmp (name, "szm") == 0) {
+        topmodel_model *topmodel;
+        topmodel = (topmodel_model *) self->data;
+        *dest = (void*)&topmodel-> szm;
+        return BMI_SUCCESS;
+    }
+    // td (parameter)
+    if (strcmp (name, "td") == 0) {
+        topmodel_model *topmodel;
+        topmodel = (topmodel_model *) self->data;
+        *dest = (void*)&topmodel-> td;
+        return BMI_SUCCESS;
+    }
+    // srmax (parameter)
+    if (strcmp (name, "srmax") == 0) {
+        topmodel_model *topmodel;
+        topmodel = (topmodel_model *) self->data;
+        *dest = (void*)&topmodel-> srmax;
+        return BMI_SUCCESS;
+    }
+    // sr0 (parameter)
+    if (strcmp (name, "sr0") == 0) {
+        topmodel_model *topmodel;
+        topmodel = (topmodel_model *) self->data;
+        *dest = (void*)&topmodel-> sr0;
+        return BMI_SUCCESS;
+    }
+    // xk0 (parameter)
+    if (strcmp (name, "xk0") == 0) {
+        topmodel_model *topmodel;
+        topmodel = (topmodel_model *) self->data;
+        *dest = (void*)&topmodel-> xk0;
+        return BMI_SUCCESS;
+    }
+    
 
     // STANDALONE Note: 
     //      When TRUE/1 there are no bmi inputs being passed

--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <assert.h>
 #include "../include/topmodel.h" 
 #include "../include/bmi.h" 
 #include "../include/bmi_topmodel.h"
-
 
 int
 main(void){
@@ -377,6 +377,23 @@ main(void){
     }
     free(names_out);
     free(names_in);
+
+    // JG Note: added 03.22.2022 to test added params get set values. 
+    // Params are not standard bmi i/o vars.
+    printf("\nTEST BMI MODEL PARAMETERS\n*************************\n");
+    //int expected_num_params = 5;
+    static const char *expected_param_names[5] = {"szm", "td", "srmax", "sr0", "xk0"};
+    double test_set_value = 4.2;
+    double test_get_value = 0.0;
+    for( int i = 0; i < 5; i++ ){
+        status = model->set_value(model, expected_param_names[i], &test_set_value);
+        //if (status == BMI_FAILURE)return BMI_FAILURE;
+        assert(status == BMI_SUCCESS);
+        status = model->get_value(model, expected_param_names[i], &test_get_value);
+        assert(status == BMI_SUCCESS);
+        assert(test_set_value == test_get_value);
+        printf(" get & set values match for parameter: %s \n", expected_param_names[i]);
+    }
     // Test BMI: CONTROL FUNCTION update_until()
     {
         int added_nstep=5;


### PR DESCRIPTION
This modification allows the Nextgen model engine to change parameter values by exposing them through BMI.

## Additions

All in `bmi_topmodel.c`:

- `PARAM_VAR_NAME_COUNT`
- `param_var_names`
- `param_var_types`

## Changes

Updated the following in `bmi_topmodel.c`:

- `Get_var_type`
- `Get_value_ptr`

## Testing

1. _IN PROGRESS_


## Todos

- Add testing functionality to ensure param values can be get/set

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [x] MacOS

Closes #28