### PR TITLE
expose t0 as a mutable parameter

### DIFF
--- a/docs/INPUT_FILES_EXPLAINED.md
+++ b/docs/INPUT_FILES_EXPLAINED.md
@@ -80,7 +80,7 @@ See [`params.dat`](../data/params.dat).
 | -------- | -------- | ------ | ----- | ---- | ------- | ----------- |
 | subcat  | *char* | 256  |   | info_string |   | character title of subcatment; often same as model title  |
 | szm     | *double* |   | meters | parameter_fixed | rainfall-runoff | exponential scaling parameter for the decline of transmissivity with increase in storage deficit; units of depth  |
-| t0   | *double* |   |  ln(meters^2) | parameter_fixed |   | areal average of ln(a/tanB)  |
+| t0   | *double* |   |  meters/hour | parameter_adjustable |   | downslope transmissivity when the soil is just saturated to the surface  |
 | td   | *double* |   |  hours | parameter_adjustable | rainfall-runoff | unsaturated zone time delay per unit storage deficit  |
 | chv  | *double* |   |  meters/hour | parameter_fixed | overland flow | average channel flow velocity   |
 | rv   | *double* |   |  meters/hour | parameter_fixed | overland flow | internal overland flow routing velocity   |

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -97,7 +97,7 @@ struct TopModel_Struct{
 
   /******* Model parameters and input scalars ******/
   double szm;   /* this is the famous m parameter */
-  double t0;    /* this is the areal average of ln(a/tanB)  */
+  double t0;    /* downslope transmissivity when the soil is just saturated to the surface  */
   double td;    /* unsaturated zome time delay per unit storage deficit */
   double srmax; /* maximum root zone storage deficit */
   double Q0;    /* initial subsurface flow per unit area */

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -144,7 +144,7 @@ static const char *input_var_locations[INPUT_VAR_NAME_COUNT] = {
 };
 
 static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
-    "t0",    // this is the areal average of ln(a/tanB)
+    "t0",    // downslope transmissivity when the soil is just saturated to the surface
     "szm",   // exponential scaling parameter for the decline of transmissivity with increase in storage deficit (m)
     "td",    // unsaturated zone time delay per unit storage deficit (h)
     "srmax", // maximum root zone storage deficit (m)


### PR DESCRIPTION
Add t0 parameter to support calibration efforts

## Additions

- t0 parameter

## Testing

1. heavily exercised via calibration runs

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
