### PR TITLE
allow cfg_file to be passed as program arg

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ and the inital NULL value is being maintained throughout model run
 */
 
 
-int main(void)
+int main(int argc, char* argv[])
 {
   
   // allocating memory to store the entire BMI structure
@@ -27,9 +27,13 @@ int main(void)
   printf("\n Registering TOPMODEL BMI model ... \n");
 #endif
   register_bmi_topmodel(model);
-
-  const char *cfg_file = "./data/topmod.run";
-
+  const char *cfg_file;
+  if(argc < 2){
+    cfg_file = "./data/topmod.run";
+  }
+  else{
+    cfg_file = argv[1];
+  }
 #if TOPMODEL_DEBUG > 1  
   printf("\n Initializeing TOPMODEL BMI model ... \n");
 #endif


### PR DESCRIPTION
Allows the standalone BMI run to accept a configuration file arg from the command line.

After building with `make` you can execute `./run_bmi` as before, and it will still look for the hard coded `./data/topmodel.run` file.

You can also run `./run_bmi path/to/data/topmodel.run` and it will use the provided configuration file instead.