### PR TITLE
Dynamic alloc

### DIFF
--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -17,6 +17,12 @@
 // Note: All errors causing program to exit will print console message
 #define TOPMODEL_DEBUG 0
 
+//The following "limits" from the original beven code
+//are now treated as warnings
+#define WARN_NUM_SUBCATCHMENTS 10
+#define WARN_HISTOGRAM_ORDINATES 20
+#define WARN_TOPODEX_INCREMENTS 30
+
 /*** Function/subroutine prototypes ***/
 extern void convert_dist_to_histords(const double * const dist_from_outlet, const int num_channels,
 					const double * const chv, const double * const rv, const double dt, double* const tch);

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -27,11 +27,11 @@
 extern void convert_dist_to_histords(const double * const dist_from_outlet, const int num_channels,
 					const double * const chv, const double * const rv, const double dt, double* const tch);
 
-extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_channels, double area,
+extern void calc_time_delay_histogram(int num_channels, double area,
 		double* tch, double *cum_dist_area_with_dist,
 		int *num_time_delay_histo_ords, int *num_delay,	double **time_delay_histogram);
 
-extern void init_water_balance(int max_atb_increments, 
+extern void init_water_balance(
 				int num_topodex_values, double dt, double *sr0, 
 				double *szm, double *Q0, double *t0, double tl,
 				double **stor_unsat_zone, double *szq,
@@ -46,10 +46,10 @@ extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat,
 	      int num_channels, int num_topodex_values, int yes_print_output,
 	      double area, double **time_delay_histogram,
 	      double *cum_dist_area_with_dist, double dt, 
-              double tl, double *dist_from_outlet, int max_atb_increments, 
-	      int max_time_delay_ordinates, int *num_time_delay_histo_ords,int *num_delay,
+        double tl, double *dist_from_outlet, 
+	      int *num_time_delay_histo_ords,int *num_delay,
 	      double *szm, double *t0, double *chv, double *rv, double *td, double *srmax, 
-              double *Q0,double *sr0, int *infex, double *xk0, double *hf, double *dth,
+        double *Q0,double *sr0, int *infex, double *xk0, double *hf, double *dth,
 	      double **stor_unsat_zone, double **deficit_local,
         double **deficit_root_zone,double *szq,double **Q,
         double *sbar, double *bal);
@@ -74,7 +74,7 @@ extern void tread(FILE *subcat_fptr,FILE *output_fptr,char *subcat,
                 int *num_topodex_values,int *num_channels,double *area,
                 double **dist_area_lnaotb, double **lnaotb, int yes_print_output,
                 double **cum_dist_area_with_dist, double *tl, 
-                double **dist_from_outlet, int maxsubcatch, int maxincr);
+                double **dist_from_outlet);
                   
 extern void expinf(int irof, int it, int rint, double *df, double *cumf,
                 double dt,double xk0, double szm, double hf);                  
@@ -161,9 +161,7 @@ struct TopModel_Struct{
 
   /************** Other internal vars **************/
   int num_sub_catchments;
-  int max_atb_increments;
-  int max_num_subcatchments;
-  int max_time_delay_ordinates;
+
   // int isc   //subcat loop no longer handled by topmod()
 
   /******************** Returns ********************/

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -22,7 +22,7 @@ extern void convert_dist_to_histords(const double * const dist_from_outlet, cons
 					const double * const chv, const double * const rv, const double dt, double* const tch);
 
 extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_channels, double area,
-		double tch[11], double *cum_dist_area_with_dist,
+		double* tch, double *cum_dist_area_with_dist,
 		int *num_time_delay_histo_ords, int *num_delay,	double **time_delay_histogram);
 
 extern void init_water_balance(int max_atb_increments, 

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -18,8 +18,8 @@
 #define TOPMODEL_DEBUG 0
 
 /*** Function/subroutine prototypes ***/
-extern void convert_dist_to_histords(double *dist_from_outlet, int num_channels,
-		double *chv, double *rv, double dt, double tch[11]);
+extern void convert_dist_to_histords(const double * const dist_from_outlet, const int num_channels,
+					const double * const chv, const double * const rv, const double dt, double* const tch);
 
 extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_channels, double area,
 		double tch[11], double *cum_dist_area_with_dist,

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -34,7 +34,7 @@ extern void init_water_balance(int max_atb_increments,
 
 extern void init_discharge_array(int *num_delay, double *Q0, double area, 
 			int *num_time_delay_histo_ords, double **time_delay_histogram,
-                        double *Q);
+                        double **Q);
 
 extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat,
 	      int num_channels, int num_topodex_values, int yes_print_output,
@@ -45,8 +45,8 @@ extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat,
 	      double *szm, double *t0, double *chv, double *rv, double *td, double *srmax, 
               double *Q0,double *sr0, int *infex, double *xk0, double *hf, double *dth,
 	      double **stor_unsat_zone, double **deficit_local,
-              double **deficit_root_zone,double *szq, double *Q,
-              double *sbar, double *bal);
+        double **deficit_root_zone,double *szq,double **Q,
+        double *sbar, double *bal);
 
                  
 extern void inputs(FILE *input_fptr, int *nstep, double *dt, double **rain,

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -38,11 +38,11 @@ extern void init_water_balance(
 				double **deficit_local, double **deficit_root_zone, 
 				double *sbar, double *bal);
 
-extern void init_discharge_array(int *num_delay, double *Q0, double area, 
+extern void init_discharge_array(int stand_alone, int *num_delay, double *Q0, double area, 
 			int *num_time_delay_histo_ords, double **time_delay_histogram,
                         double **Q);
 
-extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat,
+extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat, int stand_alone,
 	      int num_channels, int num_topodex_values, int yes_print_output,
 	      double area, double **time_delay_histogram,
 	      double *cum_dist_area_with_dist, double dt, 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -313,7 +313,7 @@ int init_config(const char* config_file, topmodel_model* model)
 	&model->szm,&model->t0,&model->chv,&model->rv,&model->td, &model->srmax,
 	&model->Q0,&model->sr0,&model->infex,&model->xk0,&model->hf,&model->dth,
 	&model->stor_unsat_zone,&model->deficit_local,&model->deficit_root_zone,
-        &model->szq,model->Q,&model->sbar, &model->bal);
+        &model->szq,&model->Q,&model->sbar, &model->bal);
     fclose(model->params_fptr);
 
 
@@ -1048,9 +1048,9 @@ static int Set_value (Bmi *self, const char *name, void *array)
 				  &topmodel->num_delay, &topmodel->time_delay_histogram);
         free(tch);
         // Reinitialise discharge array
-	init_discharge_array(&topmodel->num_delay, &topmodel->Q0, topmodel->area, 
+        init_discharge_array(&topmodel->num_delay, &topmodel->Q0, topmodel->area, 
 				&topmodel->num_time_delay_histo_ords, &topmodel->time_delay_histogram, 
-				topmodel->Q);	
+				&topmodel->Q);	
     }
 
 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -432,7 +432,7 @@ static int Update (Bmi *self)
         &topmodel->sump,&topmodel->sumae,&topmodel->sumq,&topmodel->sumrz,&topmodel->sumuz,
         &topmodel->quz, &topmodel->qb, &topmodel->qof, &topmodel->p, &topmodel->ep );
 
-    if ((topmodel->stand_alone == FALSE) & (topmodel->yes_print_output == TRUE)){
+    if ((topmodel->stand_alone == FALSE) && (topmodel->yes_print_output == TRUE)){
         fprintf(topmodel->out_hyd_fptr,"%d %lf %lf\n",topmodel->current_time_step,topmodel->Qobs[1],topmodel->Q[1]);
     }      
 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -294,22 +294,16 @@ int init_config(const char* config_file, topmodel_model* model)
         (model->contrib_area)[1]=0.0;
     }
 
-    // Set up maxes for subcat and params read-in functions
-    model-> max_atb_increments=30;
-    model-> max_num_subcatchments=10;
-    model-> max_time_delay_ordinates=20;
-
     tread(model->subcat_fptr,model->output_fptr,model->subcat,&model->num_topodex_values,&model->num_channels,
         &model->area,&model->dist_area_lnaotb,&model->lnaotb,model->yes_print_output,
-        &model->cum_dist_area_with_dist,&model->tl,&model->dist_from_outlet,
-        model->max_num_subcatchments,model->max_atb_increments);
+        &model->cum_dist_area_with_dist,&model->tl,&model->dist_from_outlet);
+
     fclose(model->subcat_fptr);
 
     
     init(model->params_fptr,model->output_fptr,model->subcat,model->num_channels,model->num_topodex_values,
         model->yes_print_output,model->area,&model->time_delay_histogram,model->cum_dist_area_with_dist,
-        model->dt,model->tl,model->dist_from_outlet,model->max_atb_increments,
-	model->max_time_delay_ordinates,&model->num_time_delay_histo_ords,&model->num_delay,
+        model->dt,model->tl,model->dist_from_outlet,&model->num_time_delay_histo_ords,&model->num_delay,
 	&model->szm,&model->t0,&model->chv,&model->rv,&model->td, &model->srmax,
 	&model->Q0,&model->sr0,&model->infex,&model->xk0,&model->hf,&model->dth,
 	&model->stor_unsat_zone,&model->deficit_local,&model->deficit_root_zone,
@@ -1040,12 +1034,12 @@ static int Set_value (Bmi *self, const char *name, void *array)
         convert_dist_to_histords(topmodel->dist_from_outlet, topmodel->num_channels,
 				&topmodel->chv, &topmodel->rv, topmodel->dt, tch);
 
-	// calculate the time_delay_histogram
-	calc_time_delay_histogram(topmodel->max_time_delay_ordinates, topmodel->num_channels, 
+        // calculate the time_delay_histogram
+        calc_time_delay_histogram(topmodel->num_channels, 
 	  			  topmodel->area, tch, 
  				  topmodel->cum_dist_area_with_dist, 
 				  &topmodel->num_time_delay_histo_ords,
-				  &topmodel->num_delay, &topmodel->time_delay_histogram);
+                  &topmodel->num_delay, &topmodel->time_delay_histogram);
         free(tch);
         // Reinitialise discharge array
         init_discharge_array(&topmodel->num_delay, &topmodel->Q0, topmodel->area, 
@@ -1065,8 +1059,8 @@ static int Set_value (Bmi *self, const char *name, void *array)
         topmodel = (topmodel_model *) self->data;
 
 	
-	// Initialize water balance and unsatrutaed storage and deficits
-	init_water_balance(topmodel->max_atb_increments, topmodel->num_topodex_values, 
+        // Initialize water balance and unsatrutaed storage and deficits
+        init_water_balance(topmodel->num_topodex_values, 
 					topmodel->dt, &topmodel->sr0, &topmodel->szm, 
 					&topmodel->Q0, &topmodel->t0, topmodel->tl,
 					&topmodel->stor_unsat_zone, &topmodel->szq, 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -302,9 +302,8 @@ int init_config(const char* config_file, topmodel_model* model)
         &model->cum_dist_area_with_dist,&model->tl,&model->dist_from_outlet);
 
     fclose(model->subcat_fptr);
-
-    
-    init(model->params_fptr,model->output_fptr,model->subcat,model->num_channels,model->num_topodex_values,
+ 
+    init(model->params_fptr,model->output_fptr,model->subcat,model->stand_alone, model->num_channels, model->num_topodex_values,
         model->yes_print_output,model->area,&model->time_delay_histogram,model->cum_dist_area_with_dist,
         model->dt,model->tl,model->dist_from_outlet,&model->num_time_delay_histo_ords,&model->num_delay,
 	&model->szm,&model->t0,&model->chv,&model->rv,&model->td, &model->srmax,
@@ -473,6 +472,7 @@ static int Update_until (Bmi *self, double t)
 
 static int Finalize (Bmi *self)
 {
+
     if (self){
         topmodel_model* model = (topmodel_model *)(self->data);
 
@@ -494,9 +494,9 @@ static int Finalize (Bmi *self)
             // framework-controlled mode.
             //-----------------------------------------------------------
             if (model->stand_alone == TRUE){
-                results(model->output_fptr,model->out_hyd_fptr,model->nstep, 
+	        results(model->output_fptr,model->out_hyd_fptr,model->nstep, 
                 model->Qobs, model->Q, model->yes_print_output);                 
-            }
+	    }
         }    
 
         if( model->Q != NULL )
@@ -1045,7 +1045,7 @@ static int Set_value (Bmi *self, const char *name, void *array)
                   &topmodel->num_delay, &topmodel->time_delay_histogram);
         free(tch);
         // Reinitialise discharge array
-        init_discharge_array(&topmodel->num_delay, &topmodel->Q0, topmodel->area, 
+        init_discharge_array(topmodel->stand_alone, &topmodel->num_delay, &topmodel->Q0, topmodel->area, 
 				&topmodel->num_time_delay_histo_ords, &topmodel->time_delay_histogram, 
 				&topmodel->Q);	
     }

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -284,12 +284,15 @@ int init_config(const char* config_file, topmodel_model* model)
         d_alloc(&model->rain,model->nstep);
         d_alloc(&model->pe,model->nstep);
         d_alloc(&model->Qobs,model->nstep);   //TODO: Consider removing this all together when framework
+        //FIXME this is no longer useful, as the follow `init` will ultimatey
+        //reallocate Q to based on the number of computed histogram ordinates
         d_alloc(&model->Q,model->nstep);
         d_alloc(&model->contrib_area,model->nstep);
 
         (model->rain)[1]=0.0;
         (model->pe)[1]=0.0;
         (model->Qobs)[1]=0.0;
+        //FIXME not really useful, as `init` will reallocate and properly initialize
         (model->Q)[1]=0.0;
         (model->contrib_area)[1]=0.0;
     }

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -1031,8 +1031,9 @@ static int Set_value (Bmi *self, const char *name, void *array)
         // assign self->data to topmodel pointer
         topmodel = (topmodel_model *) self->data;
 
-	// declare variables
-	double tch[11];
+        // declare variables
+        double* tch; //FIXME put this in topmod struct and reuse it
+        d_alloc(&tch, topmodel->num_channels);
 
 	
      	// convert from distance/area to histogram ordinate form
@@ -1045,7 +1046,7 @@ static int Set_value (Bmi *self, const char *name, void *array)
  				  topmodel->cum_dist_area_with_dist, 
 				  &topmodel->num_time_delay_histo_ords,
 				  &topmodel->num_delay, &topmodel->time_delay_histogram);
-	
+        free(tch);
         // Reinitialise discharge array
 	init_discharge_array(&topmodel->num_delay, &topmodel->Q0, topmodel->area, 
 				&topmodel->num_time_delay_histo_ords, &topmodel->time_delay_histogram, 

--- a/src/main.c
+++ b/src/main.c
@@ -48,6 +48,13 @@ int main(void)
     // Gather number of steps from input file
     // when in standalone mode.
     n = topmodel->nstep;
+    //NJF in standalone mode, one MUST allocate Q for all time steps
+    //This should probably re-considered and additional validation done
+    //that the algorithms work as intended
+    //especially with the addition of `shift_Q` in the topmodel function
+    //but for now, this prevents a fault
+    if(topmodel->Q != NULL) free(topmodel->Q);
+    d_alloc(&topmodel->Q, n);
   }
   else{
     // Otherwise define loop here

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -669,21 +669,19 @@ extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_chan
         }
       }
 
-    a1=(*time_delay_histogram)[1];
-    sumar=(*time_delay_histogram)[1];
-    (*time_delay_histogram)[1]*=area;
-    
-    if((*num_time_delay_histo_ords)>1)
-      {
-      for(ir=2;ir<=(*num_time_delay_histo_ords);ir++)
-        {
-        a2=(*time_delay_histogram)[ir];
-        (*time_delay_histogram)[ir]=a2-a1;
-        a1=a2;
-        sumar+=(*time_delay_histogram)[ir];
-        (*time_delay_histogram)[ir]*=area;
-        }
-      }
+    sumar = 0;
+    //Convert ordinates to cummulative area, should sum to 1
+    for(int i =  *num_time_delay_histo_ords; i > 1; i--){
+      (*time_delay_histogram)[i] -= (*time_delay_histogram)[i-1]*area;
+      (*time_delay_histogram)[i] *= area;
+      sumar += (*time_delay_histogram)[i];
+    }
+    sumar += (*time_delay_histogram)[1];
+    if(sumar < 0.99999 || sumar > 1.00001){
+      printf("ERROR: Histogram oridnates do not sum to 1.\n");
+      exit(-1); //FIXME this fuction should probably return an error code
+                //and the error be handled elsewhere, not just an exit here...
+    }
 
     return;
 } 

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -142,6 +142,8 @@ extern void topmod(FILE *output_fptr, int nstep, int num_topodex_values,
 /* BMI Adaption: 
   current_time_step, *sump, *sumae, *sumq, stand_alone
   added as function input parameters */
+//shift Q array to align current time step
+shift_Q(Q, num_time_delay_histo_ords);
 
 double ex[31];
 int ia,ib,in,irof,it,ir;
@@ -308,7 +310,7 @@ if(irof==1) max_contrib_area=1.0;
 (*qb)=szq*exp(-(*sbar)/szm);
 (*sbar)+=(-(*quz)+(*qb));
 *Qout=(*qb)+(*qof);
-*sumq+=(*Qout); /* BMI Adaption: *sumq now as pointer var; incl in model struct */
+
 
 /*  CHANNEL ROUTING CALCULATIONS */
 /*  allow for time delay to catchment outlet num_delay as well as  */
@@ -320,9 +322,11 @@ for(ir=1;ir<=num_time_delay_histo_ords;ir++)
   {
   in=it+num_delay+ir-1;
   if(in>current_time_step) break;
-  Q[in]=(*Qout)*time_delay_histogram[ir];
+  //Accumulate previous time dealyed flow with current
+  Q[in]+=(*Qout)*time_delay_histogram[ir];
   }
-
+  //Add current time flow to mass balance variable
+  *sumq += Q[it];
 /* BMI Adaption: replace nstep with current_time_step */
 if(yes_print_output==TRUE && in<=current_time_step)
   { 

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -642,11 +642,12 @@ extern void convert_dist_to_histords(const double * const dist_from_outlet, cons
 
 extern void calc_time_delay_histogram(int num_channels, double area,
 				double* tch, double *cum_dist_area_with_dist,
-				int *num_time_delay_histo_ords, int *num_delay,	double **time_delay_histogram) 
+				int *num_time_delay_histo_ords, int *num_delay,	
+				double **time_delay_histogram) 
 
 {
     // declare local variables
-    double time, a1, sumar, a2;
+    double time, sumar; //, a1, a2;
     int j, ir;
 
     // casting tch[num_channels] to int truncates tch[num_channels] 
@@ -968,20 +969,6 @@ calc_time_delay_histogram(num_channels, area, tch,
 			  num_delay, time_delay_histogram);
 
 
-if(yes_print_output==TRUE)
-  {
-  fprintf(output_fptr,"SZQ =  %12.5lf\n",(*szq));
-  fprintf(output_fptr,"Subcatchment routing data:\n");
-  fprintf(output_fptr,"Maximum Routing Delay  %12.5lf\n",tch[num_channels]);
-  fprintf(output_fptr,"Sum of Histogram ordinates: %10.4lf\n",sumar);
-  for(ir=1;ir<=(*num_time_delay_histo_ords);ir++)
-    {
-    fprintf(output_fptr,"%12.5lf ",(*time_delay_histogram)[ir]);
-    }
-  fprintf(output_fptr,"\n");
-  }
-
-
 // Reinitialise discharge array
 init_discharge_array(stand_alone, num_delay, Q0, area, 
 			num_time_delay_histo_ords, time_delay_histogram, 
@@ -994,13 +981,31 @@ init_water_balance(num_topodex_values,
 				stor_unsat_zone, szq, 
 				deficit_local, deficit_root_zone, sbar, bal);
 
-
 if(yes_print_output==TRUE)
   {
+
+  // calculate sum of hist ords for printing to output file
+  sumar = 0;
+  for(int i =  *num_time_delay_histo_ords; i > 1; i--){
+      sumar += (*time_delay_histogram)[i];
+    }
+  sumar += (*time_delay_histogram)[1];
+
+  fprintf(output_fptr,"SZQ =  %12.5lf\n",(*szq));
+  fprintf(output_fptr,"Subcatchment routing data:\n");
+  fprintf(output_fptr,"Maximum Routing Delay  %12.5lf\n",tch[num_channels]);
+  fprintf(output_fptr,"Sum of Histogram ordinates: %10.4lf\n",sumar);
+  for(ir=1;ir<=(*num_time_delay_histo_ords);ir++)
+    {
+    fprintf(output_fptr,"%12.5lf ",(*time_delay_histogram)[ir]);
+    }
+  fprintf(output_fptr,"\n");
+   
   fprintf(output_fptr,"Initial BAL         %12.5f\n",(*bal));
   fprintf(output_fptr,"Initial SBAR        %12.5f\n",(*sbar));
   fprintf(output_fptr,"Initial SR0         %12.5f\n",(*sr0));
   }
+  
 
 return;
 }

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -593,7 +593,8 @@ return;
  */
 
 extern void convert_dist_to_histords(const double * const dist_from_outlet, const int num_channels,
-					const double * const chv, const double * const rv, const double dt, double* const tch)
+					const double * const chv, const double * const rv, 
+					const double dt, double* const tch)
 {    
     //This function ASSUMES tch is overallocated by 1 and is indexable from (1, num_channels)
     //validate invariants
@@ -800,13 +801,10 @@ extern void init_discharge_array(int stand_alone, int *num_delay, double *Q0, do
  * @params[out] bal, pointer of type double, residual of water balance 
  */
  
-extern void init_water_balance( 
-				int num_topodex_values, double dt, double *sr0, 
-				double *szm, double *Q0, double *t0, double tl,
-				double **stor_unsat_zone, double *szq,
-				double **deficit_local, 
-        double **deficit_root_zone, double *sbar, 
-				double *bal)
+extern void init_water_balance(int num_topodex_values, double dt, double *sr0, 
+			       double *szm, double *Q0, double *t0, double tl,
+			       double **stor_unsat_zone, double *szq, double **deficit_local, 
+			       double **deficit_root_zone, double *sbar, double *bal)
 {
     // declare local variables
     double t0dt;
@@ -914,15 +912,12 @@ extern void init_water_balance(
  */
 extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat, int stand_alone,
 	      int num_channels, int num_topodex_values, int yes_print_output,
-	      double area, double **time_delay_histogram,
-	      double *cum_dist_area_with_dist, double dt, 
-        double tl, double *dist_from_outlet,
-        int *num_time_delay_histo_ords,int *num_delay,
-	      double *szm, double *t0, double *chv, double *rv, double *td, double *srmax, 
-        double *Q0,double *sr0, int *infex, double *xk0, double *hf, double *dth,
-	      double **stor_unsat_zone, double **deficit_local,
-        double **deficit_root_zone,double *szq, double **Q,
-        double *sbar, double *bal)
+	      double area, double **time_delay_histogram, double *cum_dist_area_with_dist, 
+	      double dt, double tl, double *dist_from_outlet, int *num_time_delay_histo_ords,
+	      int *num_delay, double *szm, double *t0, double *chv, double *rv, double *td, 
+	      double *srmax, double *Q0,double *sr0, int *infex, double *xk0, double *hf, double *dth,
+	      double **stor_unsat_zone, double **deficit_local, double **deficit_root_zone,double *szq, double **Q,
+              double *sbar, double *bal)
 {
 
 /***************************************************************

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -99,6 +99,14 @@
 *****************************************************************/
 #include "../include/topmodel.h"
 
+void shift_Q(double* Q, int num_ordinates){ //NJF Really don't like the +1 size assumption here
+  //memmove puts num_ordinates*sizeof(double) bytes starting at Q[1]
+  //into Q[0], effectively shifting the array by one
+  memmove(&Q[0], &Q[1], num_ordinates*sizeof(*Q));
+  //set the last value to 0.0
+  Q[num_ordinates] = 0.0;
+}
+
 extern void topmod(FILE *output_fptr, int nstep, int num_topodex_values,
                 int yes_print_output,int infex, double dt, double szm,
                 double *stor_unsat_zone, double *deficit_root_zone,

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -143,7 +143,7 @@ extern void topmod(FILE *output_fptr, int nstep, int num_topodex_values,
   current_time_step, *sump, *sumae, *sumq, stand_alone
   added as function input parameters */
 //shift Q array to align current time step
-shift_Q(Q, num_time_delay_histo_ords);
+shift_Q(Q, num_delay + num_time_delay_histo_ords);
 
 double ex[num_topodex_values+1]; //+1 to maintin 1 based array indexing
 //NJF TODO consider warning on all program limits here since this is essentially
@@ -331,6 +331,7 @@ for(ir=1;ir<=num_time_delay_histo_ords;ir++)
   //Accumulate previous time dealyed flow with current
   Q[in]+=(*Qout)*time_delay_histogram[ir];
   }
+
   //Add current time flow to mass balance variable
   *sumq += Q[it];
 /* BMI Adaption: replace nstep with current_time_step */
@@ -704,6 +705,8 @@ extern void calc_time_delay_histogram(int num_channels, double area,
     sumar += (*time_delay_histogram)[1];
     if(sumar < 0.99999 || sumar > 1.00001){
       printf("ERROR: Histogram oridnates do not sum to 1.\n");
+      printf("Check that the correct number of values for cum_dist_area_with_dist and dist_from_outlet are provided.\n");
+      printf("The number of values for each variable should be equal to the number of channels (i.e., num_channels).\n\n");
       exit(-1); //FIXME this fuction should probably return an error code
                 //and the error be handled elsewhere, not just an exit here...
     }
@@ -757,6 +760,7 @@ extern void init_discharge_array(int *num_delay, double *Q0, double area,
       in=(*num_delay)+i;
       (*Q)[in]+=(*Q0)*(area-sum);
     };
+
     return;
 }
 
@@ -943,7 +947,7 @@ printf("rv = %f\n", *rv);
 printf("\nWater balance:\n");
 printf("szm = %f\n", *szm);
 printf("sr0 = %f\n", *sr0);
-printf("t0 = %f\n", *t0);
+printf("t0 = %f\n\n", *t0);
 
 //NJF num_channels is the value provided (SHOULD COME FROM TREAD)
 //Convert distance/area form to time delay histogram ordinates

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -480,18 +480,14 @@ if((*lnaotb) == NULL){
 
 /*  num_topodex_values IS NUMBER OF A/TANB ORDINATES */
 /*  AREA IS SUBCATCHMENT AREA AS PROPORTION OF TOTAL CATCHMENT  */
+tarea = 0; //Accumulate area as it is read
 for(j=1;j<=(*num_topodex_values);j++)
   {
   fscanf(subcat_fptr,"%lf %lf",&(*dist_area_lnaotb)[j],&(*lnaotb)[j]);
+  tarea += (*dist_area_lnaotb)[j];
   }
 /*  dist_area_lnaotb IS DISTRIBUTION OF AREA WITH LN(A/TANB) */
 /*  lnaotb IS LN(A/TANB) VALUE */
-
-tarea = (*dist_area_lnaotb)[1];
-for(j=2;j<=(*num_topodex_values);j++)
-  {
-  tarea+=(*dist_area_lnaotb)[j];
-  }
 
 /*  CALCULATE AREAL INTEGRAL OF LN(A/TANB)
 *  NB.  a/tanB values should be ordered from high to low with lnaotb[1]

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -547,7 +547,7 @@ return;
  * 	the 1-based indexing was directly ported as well, so the tch buffer was over allocated by one, 
  * 	giving an array indexed 0..10, but index 0 is ignored/unsued. (BChoat)
  *
- *
+ * NJF Refactored to dynamically allocate tch based on the number of channels provided
  *
  * @params[in] dist_from_outlet, pointer to array of length num_channels of type double,
  * 	distance from outlet to point on channel with area known (i.e., to a channel; BChoat)
@@ -557,15 +557,21 @@ return;
  * @params[in] CALIBRATABLE rv, pointer of type double and length one, average internal overland flow routing velocity
  * @params[in] dt, double of length one, timestep in hours
 
- * @params(out] tch[11], double of length 11, holds histogram ordinates for each channel (BChoat)
+ * @params[out] tch, double* of length num_channels, holds histogram ordinates for each channel (BChoat)
  * 	tch is used as input in subsequent functions
- * 	Note, that although tch is an 11 element vector, position 0 is ignored. It was 
+ * 	Note, position 0 is ignored. It was 
  * 	written this way when translated from the original code.
  */
 
-extern void convert_dist_to_histords(double *dist_from_outlet, int num_channels,
-					double *chv, double *rv, double dt, double tch[11])
+extern void convert_dist_to_histords(const double * const dist_from_outlet, const int num_channels,
+					const double * const chv, const double * const rv, const double dt, double* const tch)
 {    
+    //This function ASSUMES tch is overallocated by 1 and is indexable from (1, num_channels)
+    //validate invariants
+    if(num_channels < 1){
+      printf("ERROR: convert_dist_to_histords, num channels < 1, must have at least one channel\n");
+      exit(-1); //TODO return int error code and handle error externally
+    }
     // declare local variables 
     double chvdt, rvdt;
     int j;
@@ -881,7 +887,7 @@ extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat,
 
    READS PARAMETER DATA
 ******************************************/
-double tch[11];
+double tch[num_channels+1]; //+1 to maintain 1 based indexing used by other routines
 double sumar;
 int ir;
 
@@ -910,7 +916,7 @@ printf("szm = %f\n", *szm);
 printf("sr0 = %f\n", *sr0);
 printf("t0 = %f\n", *t0);
 
-
+//NJF num_channels is the value provided (SHOULD COME FROM TREAD)
 //Convert distance/area form to time delay histogram ordinates
 convert_dist_to_histords(dist_from_outlet, num_channels, chv, rv, dt, tch);
 

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -599,9 +599,9 @@ extern void convert_dist_to_histords(const double * const dist_from_outlet, cons
  * @params[in] num_channels, int, defined in subcat.dat file
  * @params[in] area, double between 0 and 1 defining catchment area as ratio of 
  * 	entire catchment
- * @params[in] tch[11], double of length 11, holds histogram ordinates for each channel
+ * @params[in] tch, double* of length num_channels, holds histogram ordinates for each channel
  * 	output from conver_dist_to_histords()
- * 	Note, that although tch is an 11 element vector, position 0 is ignored. It was 
+ * 	Note, position 0 is ignored. It was 
  * 	written this way when translated from the original code.
  * @params[in], cum_dist_area_with_dist, pointer of length num_channels-1 and type double,
  * 	cumulative distribution of area with dist_from_outlet. 
@@ -614,7 +614,7 @@ extern void convert_dist_to_histords(const double * const dist_from_outlet, cons
  */ 
 
 extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_channels, double area,
-				double tch[11], double *cum_dist_area_with_dist,
+				double* tch, double *cum_dist_area_with_dist,
 				int *num_time_delay_histo_ords, int *num_delay,	double **time_delay_histogram) 
 
 {
@@ -630,6 +630,8 @@ extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_chan
 
     // casting tch[num_channels] to int truncates tch[num_channels] 
     // (e.g., 7.9 becomes 7)
+    //Determine how many ROUTING ORDINATES 
+    //computed, essentially, by the `dist_from_outlet` of the FARTHEST channel segment
     (*num_time_delay_histo_ords)=(int)tch[num_channels];
     
     // this is here to round up. Since casting tch as int effectively rounds down, 
@@ -638,10 +640,12 @@ extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_chan
        {
        (*num_time_delay_histo_ords)++;
        }
-
-    (*num_delay)=(int)tch[1];
+    //Determine the distance from outlet for first channel ordinate???
+    (*num_delay)=(int)tch[1]; 
     (*num_time_delay_histo_ords)-=(*num_delay);
     
+
+    //NJF so we build histogram with ordinates between 1 and "distance" between first and last channel
     for(ir=1;ir<=(*num_time_delay_histo_ords);ir++)
       {
       time=(double)(*num_delay)+(double)ir;
@@ -650,9 +654,9 @@ extern void calc_time_delay_histogram(int max_time_delay_ordinates, int num_chan
         (*time_delay_histogram)[ir]=1.0;
         }
       else
-        {
+      {
         for(j=2;j<=num_channels;j++)
-          {
+        {
           if(time<=tch[j])
     	{
     	(*time_delay_histogram)[ir]=

--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -142,8 +142,6 @@ extern void topmod(FILE *output_fptr, int nstep, int num_topodex_values,
 /* BMI Adaption: 
   current_time_step, *sump, *sumae, *sumq, stand_alone
   added as function input parameters */
-//shift Q array to align current time step
-shift_Q(Q, num_delay + num_time_delay_histo_ords);
 
 double ex[num_topodex_values+1]; //+1 to maintin 1 based array indexing
 //NJF TODO consider warning on all program limits here since this is essentially
@@ -175,8 +173,15 @@ if(yes_print_output==TRUE && current_time_step==1)
 /* BMI Adaption: Set iteration to bmi's current_time_step (standalone) or 1 (framework)
   Counter++ is handled by bmi's update()*/
 
-if (stand_alone == TRUE)it=current_time_step;
-else it=1;  
+if (stand_alone == TRUE) {
+	it=current_time_step;
+}
+else {
+        it=1; 
+        //shift Q array to align current time step
+        shift_Q(Q, num_delay + num_time_delay_histo_ords);
+}
+
 
 *qof=0.0;
 *quz=0.0;
@@ -718,6 +723,7 @@ extern void calc_time_delay_histogram(int num_channels, double area,
 
 /** 
  * Function to (re)initialize discharge array
+ * @params[in] stand_alone, int, 0 for running with ngen and 1 for running in stand alone mode
  * @params[in] num_delay, pointer of type int, number of time steps lag (delay) in channel within 
  * 	catchment to outlet. Output from calc_time_delay_histogram
  * @params[in] Q0, pointer of type double, initial subsurface flow per unit area
@@ -730,18 +736,20 @@ extern void calc_time_delay_histogram(int num_channels, double area,
  *
  * @params[out] Q, pointer of type double and length num_delay+num_time_delay_histo_ords, simulated discharge
  */
-
-extern void init_discharge_array(int *num_delay, double *Q0, double area, 
+extern void init_discharge_array(int stand_alone, int *num_delay, double *Q0, double area, 
 			int *num_time_delay_histo_ords, double **time_delay_histogram,
                         double **Q)
 {
-    //if Q is already allocated, need to free and re-compute the required size
-    if(*Q != NULL){
-      free(*Q);
-      *Q = NULL;
+    // if not in stand alone mode, then reallocate Q
+    if(stand_alone != TRUE) {
+      // if Q is already allocated, need to free and re-compute the required size
+      if(*Q != NULL){
+        free(*Q);
+        *Q = NULL;
+      }
+      //*Q = calloc(*num_delay + *num_time_delay_histo_ords + 1, sizeof(double));
+      d_alloc(Q, *num_delay + *num_time_delay_histo_ords);
     }
-    //*Q = calloc(*num_delay + *num_time_delay_histo_ords + 1, sizeof(double));
-    d_alloc(Q, *num_delay + *num_time_delay_histo_ords);
 
     // declare local variables
     double sum;
@@ -841,6 +849,7 @@ extern void init_water_balance(
  * @params[in] in_param_fptr, FILE pointer, file with parameters (e.g., params.dat)
  * @params[in] output_fptr, FILE pointer, file to which output will be written (e.g., topmod-cat.out)
  * @params[in] subcat, pointer of type char, name of subcatchment, read in from in_param_fptr file
+ * @params[in] stand_alone, int, 0 for running with ngen and 1 for running in stand alone mode
  * @params[in] num_channels, int, defined in subcat.dat file
  * @params[in] num_topodex_values, int, number of topodex histogram values 
  * 	(i.e., number of A/TANB ordinates)
@@ -902,7 +911,7 @@ extern void init_water_balance(
  * @params[out] bal, pointer of type double, residual of water balance 
  * 
  */
-extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat,
+extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat, int stand_alone,
 	      int num_channels, int num_topodex_values, int yes_print_output,
 	      double area, double **time_delay_histogram,
 	      double *cum_dist_area_with_dist, double dt, 
@@ -974,7 +983,7 @@ if(yes_print_output==TRUE)
 
 
 // Reinitialise discharge array
-init_discharge_array(num_delay, Q0, area, 
+init_discharge_array(stand_alone, num_delay, Q0, area, 
 			num_time_delay_histo_ords, time_delay_histogram, 
 			Q);
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,10 @@
 # define the C compiler to use
-CC = gcc
+CC = gcc -g
 
 # define any compile-time flags
 # for newer compiler, the right hand side is not needed...
 # ... for instance, remove the flags if using gnu/10.1.0 on Cheyenne.
-CFLAGS =
+CFLAGS = -fsanitize=address
 
 INCLUDES = -I../include
 

--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -274,7 +274,7 @@ main(void){
             {
                 status = model->get_value_ptr(model, var_name, (void**)(&var));
                 if (status == BMI_FAILURE)return BMI_FAILURE;
-                printf("   get value ptr: %f\n",var);
+                printf("   get value ptr: %f\n",*var);
             }
             // Go ahead and test set_value_*() for last time step here
             if (n == test_nstep){
@@ -338,7 +338,7 @@ main(void){
             {
                 status = model->get_value_ptr(model, var_name, (void**)(&var));
                 if (status == BMI_FAILURE)return BMI_FAILURE;
-                printf("   get value ptr: %f\n",var);
+                printf("   get value ptr: %f\n",*var);
             }
             // Go ahead and test set_value_*() for last time step here
             if (n == test_nstep){

--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -375,7 +375,13 @@ main(void){
             }
         }
     }
+    for (i=0; i<count_out; i++){ 
+        free(names_out[i]);
+    }
     free(names_out);
+    for (i=0; i<count_in; i++){
+        free(names_in[i]);
+    }
     free(names_in);
 
     // JG Note: added 03.22.2022 to test added params get set values. 
@@ -410,6 +416,7 @@ main(void){
         printf("\n finalizing...\n");
         status = model->finalize(model);
         if (status == BMI_FAILURE) return BMI_FAILURE;
+        free(model);
         printf("\n******************\nEND BMI UNIT TEST\n\n");
     }
     return 0;


### PR DESCRIPTION
This PR replaces #38 

Refactors the allocation of Q to ensure the correct size for iterating over the histogram size.

Also fixes an accumulation bug where Q was not previously accounting for the time delayed contributions.

Removes hard coded limits and issues warnings when users supply values that may violate original model assumptions.

A few code cleanup/refactors for simplifying and optmization loops.

A few other small bug fixes and comments added.

Commits were cherry-picked and applied to the master from the previous PR to prevent excessive merge conflict resolution.  I recommend rebasing these commits (not merging).