### PR TITLE
Fix memory error when chv and rv are used as calibration parameters.

### DIFF
--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -650,7 +650,7 @@ extern void calc_time_delay_histogram(int num_channels, double area,
     // declare local variables
     double time, sumar; //, a1, a2;
     int j, ir;
-
+    int tmp_num_ords = *num_time_delay_histo_ords;
     // casting tch[num_channels] to int truncates tch[num_channels] 
     // (e.g., 7.9 becomes 7)
     //Determine how many ROUTING ORDINATES 
@@ -675,8 +675,14 @@ extern void calc_time_delay_histogram(int num_channels, double area,
 
     if((*time_delay_histogram) == NULL){
       d_alloc(time_delay_histogram, *num_time_delay_histo_ords);
-    } //FIXME always free/realloc
-      //If not, the caller must ensure the correct size of time_delay_histogram prior to calling
+    } else if(tmp_num_ords != *num_time_delay_histo_ords){
+      //caller cannot know if num_time_delay_histo_ords has changed
+      //since it is computed in this function, so if the histogram exists
+      //and the number or ords has changed based on the calculations in this
+      //function, we will re-allocate it.
+      free(*time_delay_histogram);
+      d_alloc(time_delay_histogram, *num_time_delay_histo_ords);
+    }
   
     //NJF so we build histogram with ordinates between 1 and "distance" between first and last channel
     for(ir=1;ir<=(*num_time_delay_histo_ords);ir++)

--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -388,10 +388,10 @@ main(void){
     // Params are not standard bmi i/o vars.
     printf("\nTEST BMI MODEL PARAMETERS\n*************************\n");
     //int expected_num_params = 5;
-    static const char *expected_param_names[5] = {"szm", "td", "srmax", "sr0", "xk0"};
+    static const char *expected_param_names[7] = {"szm", "td", "srmax", "sr0", "xk0", "chv", "rv"};
     double test_set_value = 4.2;
     double test_get_value = 0.0;
-    for( int i = 0; i < 5; i++ ){
+    for( int i = 0; i < 7; i++ ){
         status = model->set_value(model, expected_param_names[i], &test_set_value);
         //if (status == BMI_FAILURE)return BMI_FAILURE;
         assert(status == BMI_SUCCESS);


### PR DESCRIPTION
Memory errors pop up when using `chv` as a BMI calibratable parameter.  This is due to the time delay histogram not being the correct size when `set_value` calls `calc_time_delay_histogram` since `chv` and `rv` affect the values of `tch` in `
convert_dist_to_histords` which in turn determines the number of ordinates in the `time_delay_histogram`.

This PR checks if the number of ordinates has changed and dynamically reallocates the histogram array.

## Additions

- Add `chv` and `rv` to bmi unit test parameter list

## Changes

- `topmodel.c` reallocate time_delay_histogram pointer when size changes

## Testing

1. Unit tests passing local with address sanitizer enabled using clang compiler.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support
- [x] Linux
- [x] MacOS
