### PR TITLE
Address compiler and valgrind/sanitizer warnings

### DIFF
--- a/.github/workflows/build_and_run_unit_test.yml
+++ b/.github/workflows/build_and_run_unit_test.yml
@@ -23,7 +23,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -36,13 +36,13 @@ jobs:
       run: |
         cd ./test
         make clean
-        make
+        make 'CFLAGS=-g -fsanitize=address -Werror'
         ./run_bmi_unit_test
         
     - name: Build and Run Standalone  
       run: |
         cd src/
         make clean
-        make
+        make 'CFLAGS=-g -fsanitize=address -Werror'
         cd ..
         ./run_bmi

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -24,7 +24,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -99,6 +99,7 @@ jobs:
           mod-dir: " extern/topmodel/"
           targets: "topmodelbmi"
           initialize: "false"
+          cmake-flags: "CFLAGS='-g -fsanitize=address -Werror'"
  
       - name: Run petbmi, topmodelbmi
         run: |

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -186,18 +186,27 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     path/to/topmod.out
     path/to/hyd.out */
 
+    int ret = 0;
+    char *str_ret = NULL;
+
     //Read the stand_alone T/F
     //note: newline is needed here!
-    fscanf(model->control_fptr,"%d\n",&model->stand_alone);
+    ret = fscanf(model->control_fptr,"%d\n",&model->stand_alone);
+    if (ret != 1)
+        return BMI_FAILURE;
 
     //Read the title line, up to 255 characters, of the the file
-    fgets(model->title,256,model->control_fptr);
+    str_ret = fgets(model->title,256,model->control_fptr);
+    if (str_ret == NULL)
+        return BMI_FAILURE;
     
     //Read a string, breaks on whitespace (or newline)
     //These must be done IN ORDER
     char input_fname[MAX_FILENAME_LENGTH];
     //It might be worth always scanning this line, but only opening the file if not STAND_ALONE
-    fscanf(model->control_fptr,"%s",input_fname);
+    ret = fscanf(model->control_fptr,"%s",input_fname);
+    if (ret != 1)
+        return BMI_FAILURE;
     
     //If stand_alone TRUE, read inputs from input file
     if (model->stand_alone == TRUE){
@@ -208,12 +217,20 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     };
 
     char subcat_fname[MAX_FILENAME_LENGTH],params_fname[MAX_FILENAME_LENGTH];
-    fscanf(model->control_fptr,"%s",subcat_fname);
-    fscanf(model->control_fptr,"%s",params_fname);
+    ret = fscanf(model->control_fptr,"%s",subcat_fname);
+    if (ret != 1)
+        return BMI_FAILURE;
+    ret = fscanf(model->control_fptr,"%s",params_fname);
+    if (ret != 1)
+        return BMI_FAILURE;
 
     char output_fname[MAX_FILENAME_LENGTH],out_hyd_fname[MAX_FILENAME_LENGTH];
-    fscanf(model->control_fptr,"%s",output_fname);
-    fscanf(model->control_fptr,"%s",out_hyd_fname);
+    ret = fscanf(model->control_fptr,"%s",output_fname);
+    if (ret != 1)
+        return BMI_FAILURE;
+    ret = fscanf(model->control_fptr,"%s",out_hyd_fname);
+    if (ret != 1)
+        return BMI_FAILURE;
 
     //Attempt to read the parsed input file names, bail if they cannot be read/created
     if((model->subcat_fptr=fopen(subcat_fname,"r"))==NULL){       
@@ -232,7 +249,9 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     //      If framework will never want these out files, 
     //      just use model->stand_alone as control switch
     //      move line to init_config() with others
-    fscanf(model->subcat_fptr,"%d %d %d",&model->num_sub_catchments,&model->imap,&model->yes_print_output);
+    ret = fscanf(model->subcat_fptr,"%d %d %d",&model->num_sub_catchments,&model->imap,&model->yes_print_output);
+    if (ret != 3)
+        return BMI_FAILURE;
 
     // Attempt to read the output file names only if printing to file
     if(model->yes_print_output == TRUE && model->stand_alone == TRUE){
@@ -261,7 +280,6 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     // Output files (if opened) closed in finalize()
 
     return BMI_SUCCESS;
-
 }
 
 int init_config(const char* config_file, topmodel_model* model)

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -172,7 +172,7 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     /* BMI Adaption: No longer needs to be named "topmod.run" */
     if((model->control_fptr=fopen(config_file,"r"))==NULL){
         printf("Can't open control file named %s\n",config_file);      
-        exit(-9);
+        return BMI_FAILURE;
     }
 
     /* BMI Adaption: Include stand_alone (bool) in config
@@ -203,7 +203,7 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     if (model->stand_alone == TRUE){
         if((model->input_fptr=fopen(input_fname,"r"))==NULL){
             printf("Can't open input file named %s\n",input_fname);
-            exit(-9);
+            return BMI_FAILURE;
         }
     };
 
@@ -218,12 +218,12 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     //Attempt to read the parsed input file names, bail if they cannot be read/created
     if((model->subcat_fptr=fopen(subcat_fname,"r"))==NULL){       
         printf("Can't open subcat file named %s\n",subcat_fname);
-        exit(-9);
+        return BMI_FAILURE;
     }
 
     if((model->params_fptr=fopen(params_fname,"r"))==NULL){
         printf("Can't open params file named %s\n",params_fname);   
-        exit(-9);
+        return BMI_FAILURE;
     }
     
     /* READ IN SUBCATCHMENT TOPOGRAPHIC DATA */
@@ -238,12 +238,12 @@ int read_init_config(const char* config_file, topmodel_model* model) {
     if(model->yes_print_output == TRUE && model->stand_alone == TRUE){
         if((model->output_fptr=fopen(output_fname,"w"))==NULL){           
             printf("Can't open output file named %s\n",output_fname);
-            exit(-9);
+            return BMI_FAILURE;
         }
 
         if((model->out_hyd_fptr=fopen(out_hyd_fname,"w"))==NULL){          
             printf("Can't open output file named %s\n",out_hyd_fname);
-            exit(-9);
+            return BMI_FAILURE;
         }
 
         fprintf(model->output_fptr,"%s\n",model->title);
@@ -266,7 +266,10 @@ int read_init_config(const char* config_file, topmodel_model* model) {
 
 int init_config(const char* config_file, topmodel_model* model)
 {
-    read_init_config(config_file,model);
+    int ret = BMI_SUCCESS;
+    ret = read_init_config(config_file,model);
+    if (ret != BMI_SUCCESS)
+        return ret;
     
     if (model->stand_alone == TRUE){
         /* READ IN nstep, DT and RAINFALL, PE, QOBS INPUTS */

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -402,7 +402,9 @@ static int Initialize (Bmi *self, const char *cfg_file)
     topmodel = (topmodel_model *) self->data;
 
     // Read and setup data from file
-    init_config(cfg_file, topmodel);
+    int ret = init_config(cfg_file, topmodel);
+    if (ret != BMI_SUCCESS)
+        return ret;
 
     // Initialize model varables which are cumulatively defined
     topmodel->current_time_step=0;

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -406,16 +406,17 @@ static int Initialize (Bmi *self, const char *cfg_file)
     if (ret != BMI_SUCCESS)
         return ret;
 
-    // Initialize model varables which are cumulatively defined
+    // Initialize model variables which are cumulatively defined
     topmodel->current_time_step=0;
     topmodel->sump = 0.0;
     topmodel->sumae = 0.0;
     topmodel->sumq = 0.0;
 
+    topmodel->max_contrib_area=0.0;
+
 /*    irof=0;
 rex=0.0;
 cumf=0.0;
-max_contrib_area=0.0;
 sump=0.0;
 sumae=0.0;
 sumq=0.0;

--- a/src/main.c
+++ b/src/main.c
@@ -73,5 +73,6 @@ int main(void)
 #endif
   model->finalize(model);
 
+  free(model);
   return 0;
 }


### PR DESCRIPTION
I want to enable `-Werror` on the top-level ngen CI workflows. That requires that the formulation modules that we integration test build cleanly.

## Changes

- Error check file read operations `fgets()` and `fscanf()`
- Return `BMI_FAILURE` on errors rather than `exit()`ing
- Check for `BMI_FAILURE` up the `Initialize()` call stack
- Add `-Werror` to compiler flags
- Pin OS versions in CI so that `-Werror` doesn't unexpectedly change meaning
- Initialize a variable that later gets printed
- Free the BMI object in the test driver to avoid a leak report

## Testing

Github CI

## Screenshots

Warnings seen in ngen Github CI:

```
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c: In function ‘read_init_config’:
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:191:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  191 |     fscanf(model->control_fptr,"%d\n",&model->stand_alone);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:194:5: error: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Werror=unused-result]
  194 |     fgets(model->title,256,model->control_fptr);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:200:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  200 |     fscanf(model->control_fptr,"%s",input_fname);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:211:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  211 |     fscanf(model->control_fptr,"%s",subcat_fname);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:212:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  212 |     fscanf(model->control_fptr,"%s",params_fname);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:215:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  215 |     fscanf(model->control_fptr,"%s",output_fname);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:216:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  216 |     fscanf(model->control_fptr,"%s",out_hyd_fname);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ngen/ngen/extern/topmodel/topmodel/src/bmi_topmodel.c:235:5: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  235 |     fscanf(model->subcat_fptr,"%d %d %d",&model->num_sub_catchments,&model->imap,&model->yes_print_output);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [x] macOS

