### PR TITLE
Fix compiler warnings, second try

### DIFF
--- a/.github/workflows/build_and_run_unit_test.yml
+++ b/.github/workflows/build_and_run_unit_test.yml
@@ -36,13 +36,13 @@ jobs:
       run: |
         cd ./test
         make clean
-        make 'CFLAGS=-g -fsanitize=address -Werror'
+        make 'CFLAGS=-g -Og -fsanitize=address -Werror'
         ./run_bmi_unit_test
         
     - name: Build and Run Standalone  
       run: |
         cd src/
         make clean
-        make 'CFLAGS=-g -fsanitize=address -Werror'
+        make 'CFLAGS=-g -Og -fsanitize=address -Werror'
         cd ..
         ./run_bmi

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -99,7 +99,7 @@ jobs:
           mod-dir: " extern/topmodel/"
           targets: "topmodelbmi"
           initialize: "false"
-          cmake-flags: "CFLAGS='-g -fsanitize=address -Werror'"
+          cmake-flags: "-DCMAKE_C_FLAGS='-g -fsanitize=address -Werror'"
  
       - name: Run petbmi, topmodelbmi
         run: |

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -99,7 +99,7 @@ jobs:
           mod-dir: " extern/topmodel/"
           targets: "topmodelbmi"
           initialize: "false"
-          cmake-flags: "-DCMAKE_C_FLAGS='-g -fsanitize=address -Werror'"
+          cmake-flags: "-DCMAKE_C_FLAGS='-g -Og -fsanitize=address -Werror'"
  
       - name: Run petbmi, topmodelbmi
         run: |

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -42,7 +42,7 @@ extern void init_discharge_array(int stand_alone, int *num_delay, double *Q0, do
 			int *num_time_delay_histo_ords, double **time_delay_histogram,
                         double **Q);
 
-extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat, int stand_alone,
+extern int init(FILE *in_param_fptr, FILE *output_fptr, char *subcat, int stand_alone,
 	      int num_channels, int num_topodex_values, int yes_print_output,
 	      double area, double **time_delay_histogram,
 	      double *cum_dist_area_with_dist, double dt, 
@@ -54,7 +54,7 @@ extern void init(FILE *in_param_fptr, FILE *output_fptr, char *subcat, int stand
         double **deficit_root_zone,double *szq,double **Q,
         double *sbar, double *bal);
               
-extern void inputs(FILE *input_fptr, int *nstep, double *dt, double **rain,
+extern int inputs(FILE *input_fptr, int *nstep, double *dt, double **rain,
                 double **pe, double **Qobs, double **Q, double **contrib_area);
                    
 extern void topmod(FILE *output_fptr, int nstep, int num_topodex_values,
@@ -69,7 +69,7 @@ extern void topmod(FILE *output_fptr, int nstep, int num_topodex_values,
                 double *sump, double *sumae, double *sumq, double *sumrz, double *sumuz,
                 double *quz, double *qb, double *qof, double *p, double *ep);
 
-extern void tread(FILE *subcat_fptr,FILE *output_fptr,char *subcat, 
+extern int tread(FILE *subcat_fptr,FILE *output_fptr,char *subcat,
                 int *num_topodex_values,int *num_channels,double *area,
                 double **dist_area_lnaotb, double **lnaotb, int yes_print_output,
                 int stand_alone, double **cum_dist_area_with_dist, double *tl, 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -291,8 +291,10 @@ int init_config(const char* config_file, topmodel_model* model)
     
     if (model->stand_alone == TRUE){
         /* READ IN nstep, DT and RAINFALL, PE, QOBS INPUTS */
-        inputs(model->input_fptr, &model->nstep, &model->dt, &model->rain, &model->pe, 
-            &model->Qobs, &model->Q, &model->contrib_area);
+        ret = inputs(model->input_fptr, &model->nstep, &model->dt, &model->rain, &model->pe,
+                     &model->Qobs, &model->Q, &model->contrib_area);
+        if (ret != 0)
+            return BMI_FAILURE;
         fclose(model->input_fptr);
     }
     else {
@@ -324,13 +326,15 @@ int init_config(const char* config_file, topmodel_model* model)
 
     fclose(model->subcat_fptr);
  
-    init(model->params_fptr,model->output_fptr,model->subcat,model->stand_alone, model->num_channels, model->num_topodex_values,
+    ret = init(model->params_fptr,model->output_fptr,model->subcat,model->stand_alone, model->num_channels, model->num_topodex_values,
         model->yes_print_output,model->area,&model->time_delay_histogram,model->cum_dist_area_with_dist,
         model->dt,model->tl,model->dist_from_outlet,&model->num_time_delay_histo_ords,&model->num_delay,
 	&model->szm,&model->t0,&model->chv,&model->rv,&model->td, &model->srmax,
 	&model->Q0,&model->sr0,&model->infex,&model->xk0,&model->hf,&model->dth,
 	&model->stor_unsat_zone,&model->deficit_local,&model->deficit_root_zone,
         &model->szq,&model->Q,&model->sbar, &model->bal);
+    if (ret != 0)
+        return BMI_FAILURE;
     fclose(model->params_fptr);
 
 


### PR DESCRIPTION
My previous PR #47 didn't get the flags right to actually match intentions, so the code changes to satisfy CI in that PR were incomplete. This PR fixes the flags to enforce our expectation of no compiler warnings, and fixes the code accordingly.

## Changes

- Fix variable name in CMake arguments in CI
- Add `-Og` so that the compiler does analysis necessary to see that `fgets()` and `fscanf()` return values were unchecked
- Check said return values, and report errors up the call stack through to `BMI_FAILURE`

## Testing

1. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux/GCC9 (Ubuntu 20.04)
- [x] macOS with AppleClang
