### PR TITLE
use 'os-latest` in ngen ci

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -24,7 +24,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Workflow `ngen_integration` specifically calls out mac & ubuntu versions; lets update to `-latest`.

Fixes issue #49