### PR TITLE
Replace BMI_SUCCESS/FAILURE macros with static constants per csdms/bmi-c#12

### DIFF
--- a/include/bmi.h
+++ b/include/bmi.h
@@ -35,8 +35,8 @@ SOFTWARE.
 extern "C" {
 #endif
 
-#define BMI_SUCCESS (0)
-#define BMI_FAILURE (1)
+const static int BMI_SUCCESS = 0;
+const static int BMI_FAILURE = 1;
 
 #define BMI_MAX_UNITS_NAME (2048)
 #define BMI_MAX_TYPE_NAME (2048)


### PR DESCRIPTION
This is getting in the way of NOAA-OWP/ngen#831

## Changes

- Modify `bmi/bmi.h` and `include/bmi.h` to define `BMI_SUCCESS` and `BMI_FAILURE` as `const static int` instead of `#define` macros, to avoid tripping over https://github.com/csdms/bmi-c/issues/12

## Testing

1. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
