### PR TITLE
First implementation of ngen BMI serialization protocol

### DIFF
--- a/.github/actions/build-boost/action.yml
+++ b/.github/actions/build-boost/action.yml
@@ -1,0 +1,38 @@
+name: Build Boost
+description: Build Boost.Serialization and point CMake at it
+
+inputs:
+  version:
+    description: Boost release to build.  Must satisfy the version floor in CMakeLists.txt
+    default: 1.86.0
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Boost
+      id: cache-boost
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/boost-install
+        key: boost-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
+    # Serialization is a compiled Boost library, and at present the runners' distribution packages predate the
+    # min version, so build it from source.
+    - name: Build Boost.Serialization
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        cd ${{ runner.temp }}
+        dir="boost_${VERSION//./_}"
+        curl -fsSL -o boost.tar.gz \
+          "https://archives.boost.io/release/${VERSION}/source/${dir}.tar.gz"
+        tar xzf boost.tar.gz
+        cd "$dir"
+        ./bootstrap.sh --with-libraries=serialization --prefix=${{ runner.temp }}/boost-install
+        ./b2 install --with-serialization link=shared -j"$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Point CMake at Boost
+      shell: bash
+      run: echo "CMAKE_PREFIX_PATH=${{ runner.temp }}/boost-install" >> "$GITHUB_ENV"

--- a/.github/actions/build-boost/action.yml
+++ b/.github/actions/build-boost/action.yml
@@ -9,9 +9,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Cache Boost
+    # Restore and save separately rather than with the combined cache action, where save runs as a post step.
+    # This is to avoid side effects of any workspace-replacement trickery that may be occurring.
+    - name: Restore Boost
       id: cache-boost
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ${{ runner.temp }}/boost-install
         key: boost-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -32,6 +34,13 @@ runs:
         cd "$dir"
         ./bootstrap.sh --with-libraries=serialization --prefix=${{ runner.temp }}/boost-install
         ./b2 install --with-serialization link=shared -j"$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Save Boost
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/boost-install
+        key: ${{ steps.cache-boost.outputs.cache-primary-key }}
 
     - name: Point CMake at Boost
       shell: bash

--- a/.github/workflows/build_and_run_unit_test.yml
+++ b/.github/workflows/build_and_run_unit_test.yml
@@ -68,6 +68,16 @@ jobs:
         cd cmake_build/
         ./simple_unit_tests
 
+    - name: Build and Run Serialization Tests
+      run: |
+        cmake -B cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -DCMAKE_CXX_FLAGS="-g -Og -fsanitize=address -Werror" -S .
+        cmake --build cmake_build --target clean
+        cmake --build cmake_build --target serialization_unit_tests
+        cmake --build cmake_build --target serialization_integration_tests
+        cd cmake_build/
+        ./serialization_unit_tests
+        ./serialization_integration_tests
+
     - name: Build and Run Standalone
       run: |
         cmake -B cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -DCMAKE_CXX_FLAGS="-g -Og -fsanitize=address -Werror" -S .

--- a/.github/workflows/build_and_run_unit_test.yml
+++ b/.github/workflows/build_and_run_unit_test.yml
@@ -15,9 +15,6 @@ env:
   # TODO: add something later that can check the runners for hyperthreading
   LINUX_NUM_PROC_CORES: 2
   MACOS_NUM_PROC_CORES: 3
-  # Must satisfy the version floor in CMakeLists.txt
-  BOOST_VERSION: 1.86.0
-  BOOST_VERSION_UNDERSCORE: 1_86_0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -35,28 +32,8 @@ jobs:
     - name: Checkout the commit
       uses: actions/checkout@v4
 
-    - name: Cache Boost
-      id: cache-boost
-      uses: actions/cache@v4
-      with:
-        path: ${{ runner.temp }}/boost-install
-        key: boost-${{ env.BOOST_VERSION }}-${{ runner.os }}-${{ runner.arch }}
-
-    # Serialization is a compiled Boost library, and the runners' distribution
-    # packages predate the version floor, so build just that one from source.
-    - name: Build Boost.Serialization
-      if: steps.cache-boost.outputs.cache-hit != 'true'
-      run: |
-        cd ${{ runner.temp }}
-        curl -fsSL -o boost.tar.gz \
-          "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
-        tar xzf boost.tar.gz
-        cd "boost_${BOOST_VERSION_UNDERSCORE}"
-        ./bootstrap.sh --with-libraries=serialization --prefix=${{ runner.temp }}/boost-install
-        ./b2 install --with-serialization link=shared -j"$(getconf _NPROCESSORS_ONLN)"
-
-    - name: Point CMake at Boost
-      run: echo "CMAKE_PREFIX_PATH=${{ runner.temp }}/boost-install" >> "$GITHUB_ENV"
+    - name: Build Boost
+      uses: ./.github/actions/build-boost
 
     # These targets now include a C++ source, so they link with the C++ driver;
     # the sanitizer has to be on the CXX flags too or its runtime is left out.

--- a/.github/workflows/build_and_run_unit_test.yml
+++ b/.github/workflows/build_and_run_unit_test.yml
@@ -15,6 +15,9 @@ env:
   # TODO: add something later that can check the runners for hyperthreading
   LINUX_NUM_PROC_CORES: 2
   MACOS_NUM_PROC_CORES: 3
+  # Must satisfy the version floor in CMakeLists.txt
+  BOOST_VERSION: 1.86.0
+  BOOST_VERSION_UNDERSCORE: 1_86_0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -31,10 +34,35 @@ jobs:
     steps:
     - name: Checkout the commit
       uses: actions/checkout@v4
-    
+
+    - name: Cache Boost
+      id: cache-boost
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/boost-install
+        key: boost-${{ env.BOOST_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+    # Serialization is a compiled Boost library, and the runners' distribution
+    # packages predate the version floor, so build just that one from source.
+    - name: Build Boost.Serialization
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+      run: |
+        cd ${{ runner.temp }}
+        curl -fsSL -o boost.tar.gz \
+          "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+        tar xzf boost.tar.gz
+        cd "boost_${BOOST_VERSION_UNDERSCORE}"
+        ./bootstrap.sh --with-libraries=serialization --prefix=${{ runner.temp }}/boost-install
+        ./b2 install --with-serialization link=shared -j"$(getconf _NPROCESSORS_ONLN)"
+
+    - name: Point CMake at Boost
+      run: echo "CMAKE_PREFIX_PATH=${{ runner.temp }}/boost-install" >> "$GITHUB_ENV"
+
+    # These targets now include a C++ source, so they link with the C++ driver;
+    # the sanitizer has to be on the CXX flags too or its runtime is left out.
     - name: Build and Run Unit Test
       run: |
-        cmake -B cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -S .
+        cmake -B cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -DCMAKE_CXX_FLAGS="-g -Og -fsanitize=address -Werror" -S .
         cmake --build cmake_build --target clean
         cmake --build cmake_build --target simple_unit_tests
         cd cmake_build/
@@ -42,7 +70,7 @@ jobs:
 
     - name: Build and Run Standalone
       run: |
-        cmake -B cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -S .
+        cmake -B cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -DCMAKE_CXX_FLAGS="-g -Og -fsanitize=address -Werror" -S .
         cmake --build cmake_build --target clean
         cmake --build cmake_build --target topmodeldriver
         ./cmake_build/topmodeldriver

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -16,9 +16,6 @@ env:
   LINUX_NUM_PROC_CORES: 2
   MACOS_NUM_PROC_CORES: 3
   ASAN_OPTIONS: detect_leaks=false
-  # Must satisfy the version floor in CMakeLists.txt
-  BOOST_VERSION: 1.86.0
-  BOOST_VERSION_UNDERSCORE: 1_86_0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -36,6 +33,10 @@ jobs:
       # Checkout and save the topmodel to a temporary directory
       - name: Checkout the commit
         uses: actions/checkout@v4
+
+      # Has to be run before ngen checkout below takes over workspace.  Installs outside the workspace, so still works.
+      - name: Build Boost
+        uses: ./.github/actions/build-boost
 
       - name: Save Topmodel to a Temp Directory
         run: |
@@ -103,29 +104,6 @@ jobs:
           bmi_c: 'ON'
           bmi_fortran: 'ON'
         timeout-minutes: 15
-
-      - name: Cache Boost
-        id: cache-boost
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/boost-install
-          key: boost-${{ env.BOOST_VERSION }}-${{ runner.os }}-${{ runner.arch }}
-
-      # Serialization is a compiled Boost library, and the runners' distribution
-      # packages predate the version floor, so build just that one from source.
-      - name: Build Boost.Serialization
-        if: steps.cache-boost.outputs.cache-hit != 'true'
-        run: |
-          cd ${{ runner.temp }}
-          curl -fsSL -o boost.tar.gz \
-            "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
-          tar xzf boost.tar.gz
-          cd "boost_${BOOST_VERSION_UNDERSCORE}"
-          ./bootstrap.sh --with-libraries=serialization --prefix=${{ runner.temp }}/boost-install
-          ./b2 install --with-serialization link=shared -j"$(getconf _NPROCESSORS_ONLN)"
-
-      - name: Point CMake at Boost
-        run: echo "CMAKE_PREFIX_PATH=${{ runner.temp }}/boost-install" >> "$GITHUB_ENV"
 
       # For the time being, generate a CMake build directory aligned as if this was a submodule (i.e., under extern/)
       # However, don't use the code or CMakeLists.txt there (and don't use ngen-submod-build)

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -16,6 +16,9 @@ env:
   LINUX_NUM_PROC_CORES: 2
   MACOS_NUM_PROC_CORES: 3
   ASAN_OPTIONS: detect_leaks=false
+  # Must satisfy the version floor in CMakeLists.txt
+  BOOST_VERSION: 1.86.0
+  BOOST_VERSION_UNDERSCORE: 1_86_0
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -101,10 +104,35 @@ jobs:
           bmi_fortran: 'ON'
         timeout-minutes: 15
 
+      - name: Cache Boost
+        id: cache-boost
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/boost-install
+          key: boost-${{ env.BOOST_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      # Serialization is a compiled Boost library, and the runners' distribution
+      # packages predate the version floor, so build just that one from source.
+      - name: Build Boost.Serialization
+        if: steps.cache-boost.outputs.cache-hit != 'true'
+        run: |
+          cd ${{ runner.temp }}
+          curl -fsSL -o boost.tar.gz \
+            "https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+          tar xzf boost.tar.gz
+          cd "boost_${BOOST_VERSION_UNDERSCORE}"
+          ./bootstrap.sh --with-libraries=serialization --prefix=${{ runner.temp }}/boost-install
+          ./b2 install --with-serialization link=shared -j"$(getconf _NPROCESSORS_ONLN)"
+
+      - name: Point CMake at Boost
+        run: echo "CMAKE_PREFIX_PATH=${{ runner.temp }}/boost-install" >> "$GITHUB_ENV"
+
       # For the time being, generate a CMake build directory aligned as if this was a submodule (i.e., under extern/)
       # However, don't use the code or CMakeLists.txt there (and don't use ngen-submod-build)
+      # The library now includes a C++ source, so it links with the C++ driver; the
+      # sanitizer has to be on the CXX flags too or its runtime is left out.
       - name: Prepare to Build Topmodel Library for Ngen
-        run: cmake -B extern/topmodel/cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -S ${{runner.temp}}/topmodel/
+        run: cmake -B extern/topmodel/cmake_build -DCMAKE_C_FLAGS="-g -Og -fsanitize=address -Werror" -DCMAKE_CXX_FLAGS="-g -Og -fsanitize=address -Werror" -S ${{runner.temp}}/topmodel/
 
       - name: Build Topmodel
         id: submod_build_4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,18 @@ if (TESTS_WITH_ASAN)
 endif ()
 ####################
 
+####################
+# Stuff for ngen serialization protocol conformance tests
+add_executable(serialization_unit_tests test/main_unit_test_serialization.c src/bmi_topmodel.c src/topmodel.c src/bmi_serialization.cpp)
+target_compile_definitions(serialization_unit_tests PRIVATE REPO_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(serialization_unit_tests PRIVATE include)
+target_link_libraries(serialization_unit_tests m Boost::serialization)
+if (TESTS_WITH_ASAN)
+    target_compile_options(serialization_unit_tests PRIVATE -fsanitize=address)
+    target_link_options(serialization_unit_tests PRIVATE -fsanitize=address)
+endif ()
+####################
+
 include(GNUInstallDirs)
 
 install(TARGETS topmodelbmi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,18 @@ if (TESTS_WITH_ASAN)
 endif ()
 ####################
 
+####################
+# Stuff for long-run restart equivalence tests; run separately from the others
+add_executable(serialization_integration_tests test/main_integration_test_serialization.c src/bmi_topmodel.c src/topmodel.c src/bmi_serialization.cpp)
+target_compile_definitions(serialization_integration_tests PRIVATE REPO_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(serialization_integration_tests PRIVATE include)
+target_link_libraries(serialization_integration_tests m Boost::serialization)
+if (TESTS_WITH_ASAN)
+    target_compile_options(serialization_integration_tests PRIVATE -fsanitize=address)
+    target_link_options(serialization_integration_tests PRIVATE -fsanitize=address)
+endif ()
+####################
+
 include(GNUInstallDirs)
 
 install(TARGETS topmodelbmi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,19 +32,38 @@ set(TOPMODEL_LIB_DESC_CMAKE "OWP TOPMODEL Model and BMI Module Shared Library")
 # Some global properties
 set_property(GLOBAL PROPERTY C_STANDARD 99)      # Note that code requires minimum of C99 standard to compile
 set_property(GLOBAL PROPERTY C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)                       # State serialization is implemented in C++
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+####################
+
+####################
+# Boost, for state serialization.  Version floor matches ngen's.
+if (POLICY CMP0144)
+    cmake_policy(SET CMP0144 NEW)    # Honor the BOOST_ROOT environment variable
+endif ()
+if (POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)    # Prefer Boost's own config over the removed FindBoost module
+endif ()
+# A Boost built in place with b2 stages its libraries and CMake config files under
+# <BOOST_ROOT>/stage, which is not a prefix find_package would search on its own.
+if (DEFINED ENV{BOOST_ROOT} AND IS_DIRECTORY "$ENV{BOOST_ROOT}/stage/lib/cmake")
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{BOOST_ROOT}/stage")
+endif ()
+set(Boost_USE_STATIC_LIBS OFF)
+find_package(Boost 1.86.0 REQUIRED COMPONENTS serialization)
 ####################
 
 ####################
 # Stuff for shared library
 if(WIN32)
-    add_library(topmodelbmi src/bmi_topmodel.c src/topmodel.c)
+    add_library(topmodelbmi src/bmi_topmodel.c src/topmodel.c src/bmi_serialization.cpp)
 else()
-    add_library(topmodelbmi SHARED src/bmi_topmodel.c src/topmodel.c)
+    add_library(topmodelbmi SHARED src/bmi_topmodel.c src/topmodel.c src/bmi_serialization.cpp)
 endif()
 
 target_compile_definitions(topmodelbmi PRIVATE BMI_ACTIVE)
 target_include_directories(topmodelbmi PRIVATE include)
-target_link_libraries(topmodelbmi m)
+target_link_libraries(topmodelbmi m Boost::serialization)
 set_target_properties(topmodelbmi PROPERTIES
         VERSION ${PROJECT_VERSION}
         PUBLIC_HEADER include/bmi_topmodel.h
@@ -53,17 +72,17 @@ set_target_properties(topmodelbmi PROPERTIES
 
 ####################
 # Stuff for standalone driver executable
-add_executable(topmodeldriver src/main.c src/bmi_topmodel.c src/topmodel.c)
+add_executable(topmodeldriver src/main.c src/bmi_topmodel.c src/topmodel.c src/bmi_serialization.cpp)
 target_include_directories(topmodeldriver PRIVATE include)
-target_link_libraries(topmodeldriver m)
+target_link_libraries(topmodeldriver m Boost::serialization)
 ####################
 
 ####################
 # Stuff for simple test routine
-add_executable(simple_unit_tests test/main_unit_test_bmi.c src/bmi_topmodel.c src/topmodel.c)
+add_executable(simple_unit_tests test/main_unit_test_bmi.c src/bmi_topmodel.c src/topmodel.c src/bmi_serialization.cpp)
 target_compile_definitions(simple_unit_tests PRIVATE REPO_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(simple_unit_tests PRIVATE include)
-target_link_libraries(simple_unit_tests m)
+target_link_libraries(simple_unit_tests m Boost::serialization)
 if (TESTS_WITH_ASAN)
     # Seems this should work in all compiler
     target_compile_options(simple_unit_tests PRIVATE -fsanitize=address)

--- a/include/bmi_serialization.h
+++ b/include/bmi_serialization.h
@@ -1,0 +1,17 @@
+#ifndef TOPMODEL_SERIALIZE_HPP
+#define TOPMODEL_SERIALIZE_HPP
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "bmi.h"
+
+const int serialize_topmodel(Bmi* bmi);
+const int deserialize_topmodel(Bmi* bmi, const char* buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/bmi_serialization.h
+++ b/include/bmi_serialization.h
@@ -5,10 +5,12 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 #include "bmi.h"
 
 const int serialize_topmodel(Bmi* bmi);
-const int deserialize_topmodel(Bmi* bmi, char* buffer);
+const int deserialize_topmodel(Bmi* bmi, char* buffer, int64_t size);
 
 #ifdef __cplusplus
 }

--- a/include/bmi_serialization.h
+++ b/include/bmi_serialization.h
@@ -8,7 +8,7 @@ extern "C" {
 #include "bmi.h"
 
 const int serialize_topmodel(Bmi* bmi);
-const int deserialize_topmodel(Bmi* bmi, const char* buffer);
+const int deserialize_topmodel(Bmi* bmi, char* buffer);
 
 #ifdef __cplusplus
 }

--- a/include/ngen_utilities.h
+++ b/include/ngen_utilities.h
@@ -1,0 +1,58 @@
+#ifndef TOPMODEL_NGEN_UTILITIES_H
+#define TOPMODEL_NGEN_UTILITIES_H
+
+/*
+ * ngen serialization protocol -- opt-in BMI state checkpoint/restore.
+ *
+ * The four reserved variables are discovered by name rather than enumeration, so
+ * they must stay out of GetInputVarNames/GetOutputVarNames while still resolving
+ * through GetVarType, GetVarUnits, GetVarItemsize and GetVarNbytes.  The engine's
+ * support probe is GetVarUnits alone, compared exactly against the units below.
+ *
+ * Save:    SetValue(create) -> GetValue(size) -> GetValue(state) -> SetValue(free)
+ * Restore: SetValue(state, payload)
+ */
+
+#include <string.h>
+
+#define NGEN_SERIALIZATION_CREATE "ngen::serialization_create"
+#define NGEN_SERIALIZATION_FREE   "ngen::serialization_free"
+#define NGEN_SERIALIZATION_SIZE   "ngen::serialization_size"
+#define NGEN_SERIALIZATION_STATE  "ngen::serialization_state"
+
+/* Index into each of the tables below */
+enum {
+    SER_VAR_CREATE = 0,
+    SER_VAR_FREE,
+    SER_VAR_SIZE,
+    SER_VAR_STATE,
+    SER_VAR_COUNT
+};
+
+static const char *serialization_var_names[SER_VAR_COUNT] = {
+    NGEN_SERIALIZATION_CREATE, NGEN_SERIALIZATION_FREE,
+    NGEN_SERIALIZATION_SIZE,   NGEN_SERIALIZATION_STATE
+};
+
+static const char *serialization_var_types[SER_VAR_COUNT] = {
+    "int", "int", "int", "char"
+};
+
+static const char *serialization_var_units[SER_VAR_COUNT] = {
+    "ngen::trigger", "ngen::trigger", "bytes", "ngen::opaque"
+};
+
+/* state is sized by the model, so it gets a count of 0 here */
+static const int serialization_var_item_count[SER_VAR_COUNT] = {1, 1, 1, 0};
+
+/* Index of a reserved variable, or -1 if name is not one */
+static inline int serialization_var_index(const char *name)
+{
+    for (int i = 0; i < SER_VAR_COUNT; i++) {
+        if (strcmp(name, serialization_var_names[i]) == 0)
+            return i;
+    }
+    return -1;
+}
+
+#endif

--- a/include/ngen_utilities.h
+++ b/include/ngen_utilities.h
@@ -10,7 +10,7 @@
  * support probe is GetVarUnits alone, compared exactly against the units below.
  *
  * Save:    SetValue(create) -> GetValue(size) -> GetValue(state) -> SetValue(free)
- * Restore: SetValue(state, payload)
+ * Restore: SetValue(size, bytes) -> SetValue(state, payload)
  */
 
 #include <string.h>
@@ -35,7 +35,7 @@ static const char *serialization_var_names[SER_VAR_COUNT] = {
 };
 
 static const char *serialization_var_types[SER_VAR_COUNT] = {
-    "int", "int", "int", "char"
+    "int", "int", "int64", "char"
 };
 
 static const char *serialization_var_units[SER_VAR_COUNT] = {

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -91,9 +91,11 @@ extern void i_alloc(int **var,int size);
 
 /*** Serialized state restore behavior ***/
 
-/* How much of a snapshot applies to the run restoring it.  A hotstart begins a
-   new simulation from the physical state alone; a resume continues the run that
-   wrote the snapshot, and so also takes its clock and accumulated totals. */
+/* How much of a snapshot applies to the run restoring it.  Both modes take every
+   archived value and differ only in the clock, which carries over on a resume but
+   not on a hotstart.
+   TODO: which of the rest genuinely belongs to a new simulation is not yet
+   established; until it is, all of it is applied under either mode. */
 typedef enum {
     TOPMODEL_RESTORE_HOTSTART = 0,
     TOPMODEL_RESTORE_RESUME

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -6,6 +6,7 @@
 #include <float.h>
 #include <math.h>
 #include <string.h>
+#include <stdint.h>
 
 #define TRUE  1
 #define FALSE 0
@@ -187,6 +188,10 @@ struct TopModel_Struct{
 
   /************** Test State **************/
   //double dbl_arr_test[3];
+
+  /************** Model State **************/
+  char* serialized;
+  uint64_t serialized_length;
 
 };
 

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -89,6 +89,16 @@ extern void d_alloc(double **var,int size);
 extern void i_alloc(int **var,int size);
 
 
+/*** Serialized state restore behavior ***/
+
+/* How much of a snapshot applies to the run restoring it.  A hotstart begins a
+   new simulation from the physical state alone; a resume continues the run that
+   wrote the snapshot, and so also takes its clock and accumulated totals. */
+typedef enum {
+    TOPMODEL_RESTORE_HOTSTART = 0,
+    TOPMODEL_RESTORE_RESUME
+} topmodel_restore_mode;
+
 /*** Model structure ***/
 
 // Changed: "struct topmodel_model{" to "struct TopModel_Struct{"
@@ -191,6 +201,7 @@ struct TopModel_Struct{
   /************** Model State **************/
   char* serialized;      /* serialized state buffer; NULL when none held */
   int serialized_length; /* bytes in serialized; int because GetValue hands out its address */
+  topmodel_restore_mode restore_mode; /* how much of a snapshot to apply */
 
 };
 

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -6,7 +6,6 @@
 #include <float.h>
 #include <math.h>
 #include <string.h>
-#include <stdint.h>
 
 #define TRUE  1
 #define FALSE 0
@@ -190,8 +189,8 @@ struct TopModel_Struct{
   //double dbl_arr_test[3];
 
   /************** Model State **************/
-  char* serialized;
-  uint64_t serialized_length;
+  char* serialized;      /* serialized state buffer; NULL when none held */
+  int serialized_length; /* bytes in serialized; int because GetValue hands out its address */
 
 };
 

--- a/include/topmodel.h
+++ b/include/topmodel.h
@@ -1,6 +1,7 @@
 #ifndef TOPMODEL_H
 #define TOPMODEL_H
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
@@ -201,8 +202,8 @@ struct TopModel_Struct{
   //double dbl_arr_test[3];
 
   /************** Model State **************/
-  char* serialized;      /* serialized state buffer; NULL when none held */
-  int serialized_length; /* bytes in serialized; int because GetValue hands out its address */
+  char* serialized;          /* serialized state buffer; NULL when none held */
+  int64_t serialized_length; /* bytes of state; 64 bit as the protocol requires */
   topmodel_restore_mode restore_mode; /* how much of a snapshot to apply */
 
 };

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -1,0 +1,115 @@
+#ifndef HPP_STRING_VECBUF
+#define HPP_STRING_VECBUF
+// https://gist.github.com/stephanlachnit/4a06f8475afd144e73235e2a2584b000
+// SPDX-FileCopyrightText: 2023 Stephan Lachnit
+// SPDX-License-Identifier: MIT
+
+#include <streambuf>
+#include <string>
+#include <vector>
+
+template<class CharT = char, class Traits = std::char_traits<CharT>>
+class vecbuf : public std::basic_streambuf<CharT> {
+public:
+    using streambuf = std::basic_streambuf<CharT, Traits>;
+    using char_type = typename streambuf::char_type;
+    using int_type = typename streambuf::int_type;
+    using traits_type = typename streambuf::traits_type;
+    using vector = std::vector<char_type>;
+    using value_type = typename vector::value_type;
+    using size_type = typename vector::size_type;
+
+    // Constructor for vecbuf with optional initial capacity
+    vecbuf(size_type capacity = 0) : vector_() { reserve(capacity); }
+
+    // Forwarder for std::vector::shrink_to_fit()
+    constexpr void shrink_to_fit() { vector_.shrink_to_fit(); }
+    
+    // Forwarder for std::vector::clear()
+    constexpr void clear() { vector_.clear(); }
+
+    // Forwarder for std::vector::reserve
+    constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
+
+    // Increase the capacity of the buffer by reserving the current_size + additional_capacity
+    constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
+
+    // Forwarder for std::vector::data
+    constexpr const value_type* data() const { return vector_.data(); }
+
+    // Forwarder for std::vector::size
+    constexpr size_type size() const { return vector_.size(); }
+
+    // Forwarder for std::vector::capacity
+    constexpr size_type capacity() const { return vector_.capacity(); }
+
+    // Implements std::basic_streambuf::xsputn
+    std::streamsize xsputn(const char_type* s, std::streamsize count) override {
+        try {
+            reserve_additional(count);
+        }
+        catch (const std::bad_alloc& error) {
+            // reserve did not work, use slow algorithm
+            return xsputn_slow(s, count);
+        }
+        // reserve worked, use fast algorithm
+        return xsputn_fast(s, count);
+    }
+
+protected:
+    // Calculates value to std::basic_streambuf::pbase from vector
+    constexpr value_type* pbase_from_vector() const { return const_cast<value_type*>(vector_.data()); }
+
+    // Calculates value to std::basic_streambuf::pptr from vector
+    constexpr value_type* pptr_from_vector() const { return const_cast<value_type*>(vector_.data() + vector_.size()); }
+
+    // Calculates value to std::basic_streambuf::epptr from vector
+    constexpr value_type* epptr_from_vector() const { return const_cast<value_type*>(vector_.data()) + vector_.capacity(); }
+
+    // Sets the values for std::basic_streambuf::pbase, std::basic_streambuf::pptr and std::basic_streambuf::epptr from vector
+    constexpr void setp_from_vector() { streambuf::setp(pbase_from_vector(), epptr_from_vector()); streambuf::pbump(size()); }
+
+private:
+    // std::vector containing the data
+    vector vector_;
+
+    // Fast implementation of std::basic_streambuf::xsputn if reserve_additional(count) succeeded
+    std::streamsize xsputn_fast(const char_type* s, std::streamsize count) {
+        // store current pptr (end of vector location)
+        auto* old_pptr = pptr_from_vector();
+        // resize the vector, does not move since space already reserved
+        vector_.resize(vector_.size() + count);
+        // directly memcpy new content to old pptr (end of vector before it was resized)
+        traits_type::copy(old_pptr, s, count);
+        // reserve() already calls setp_from_vector(), only adjust pptr to new epptr
+        streambuf::pbump(count);
+
+        return count;
+    }
+
+    // Slow implementation of std::basic_streambuf::xsputn if reserve_additional(count) did not succeed, might calls std::basic_streambuf::overflow()
+    std::streamsize xsputn_slow(const char_type* s, std::streamsize count) {
+        // reserving entire vector failed, emplace char for char
+        std::streamsize written = 0;
+        while (written < count) {
+            try {
+                // copy one char, should throw eventually std::bad_alloc
+                vector_.emplace_back(s[written]);
+            }
+            catch (const std::bad_alloc& error) {
+                // try overflow(), if eof return, else continue
+                int_type c = this->overflow(traits_type::to_int_type(s[written]));
+                if (traits_type::eq_int_type(c, traits_type::eof())) {
+                    return written;
+                }
+            }
+            // update pbase, pptr and epptr
+            setp_from_vector();
+            written++;
+        }
+        return written;
+    }
+
+};
+
+#endif

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -6,6 +6,7 @@ extern "C" {
 #include "../include/bmi_serialization.h"
 
 #include <stdexcept>
+#include <vector>
 
 #include <boost/serialization/serialization.hpp>
 #include <boost/archive/binary_iarchive.hpp>
@@ -32,6 +33,35 @@ class TopmodelSerializer {
 #define TOPMODEL_SERIALIZATION_LAYOUT_VERSION 1
 BOOST_CLASS_VERSION(TopmodelSerializer, TOPMODEL_SERIALIZATION_LAYOUT_VERSION)
 
+/*
+ * Archive a field in both directions, applying an incoming value only when it
+ * belongs to the run doing the restoring.  The value is always written and always
+ * read, so the byte layout does not depend on what is applied.
+ */
+template<class Archive, class T>
+static void archive_field(Archive& ar, T& value, bool apply) {
+    if (Archive::is_saving::value) {
+        ar & value;
+    } else {
+        T incoming;
+        ar & incoming;
+        if (apply)
+            value = incoming;
+    }
+}
+
+template<class Archive>
+static void archive_array_field(Archive& ar, double* values, int count, bool apply) {
+    if (Archive::is_saving::value) {
+        ar & boost::serialization::make_array(values, count);
+    } else {
+        std::vector<double> incoming(count);
+        ar & boost::serialization::make_array(incoming.data(), count);
+        if (apply)
+            memcpy(values, incoming.data(), (size_t)count * sizeof(double));
+    }
+}
+
 
 template<class Archive>
 void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
@@ -50,14 +80,18 @@ void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
         fprintf(stderr, "%s\n", error);
         throw std::runtime_error(error);
     }
-    ar & model->current_time_step;
+    // The clock and the totals below describe the run that wrote the snapshot,
+    // so they carry over only when this run is continuing it.
+    const bool resume = model->restore_mode == TOPMODEL_RESTORE_RESUME;
+
+    archive_field(ar, model->current_time_step, resume);
 
     // data summed between runs
-    ar & model->sump; //
-    ar & model->sumae; //
-    ar & model->sumq; //
-    ar & model->sumrz; // reassigned each update; not used for calcs
-    ar & model->sumuz; // reassigned each update; not used for calcs
+    archive_field(ar, model->sump, resume);
+    archive_field(ar, model->sumae, resume);
+    archive_field(ar, model->sumq, resume);
+    archive_field(ar, model->sumrz, resume); // reassigned each update; not used for calcs
+    archive_field(ar, model->sumuz, resume); // reassigned each update; not used for calcs
 
     // outputs of Update
     ar & model->Qout; // reassigned each update; not used for calcs
@@ -86,30 +120,30 @@ void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
         model->contrib_area, model->nstep + 1
     );
 
-    // copy the current sizes to detect changes, then archive the model value
+    // Channel routing counts come from config, so this run's own values stand.
+    // A snapshot that disagrees describes a different catchment setup and is
+    // refused rather than resized into.
     int num_time_delay_histo_ords = model->num_time_delay_histo_ords;
-    ar & model->num_time_delay_histo_ords;
+    ar & num_time_delay_histo_ords;
     int num_delay = model->num_delay;
-    ar & model->num_delay;
-    size_t num_Q = model->num_delay + model->num_time_delay_histo_ords + 1;
-    if (Archive::is_loading::value) {
-        // if loading and array size has changed, reallocate
-        if (num_time_delay_histo_ords != model->num_time_delay_histo_ords) {
-            if (model->time_delay_histogram != NULL)
-                free(model->time_delay_histogram);
-            model->time_delay_histogram = (double *)malloc(
-                (model->num_time_delay_histo_ords + 1) * sizeof(double)
-            );
-        }
-        if (num_delay != model->num_delay || num_time_delay_histo_ords != model->num_time_delay_histo_ords) {
-            if (model->Q != NULL)
-                free(model->Q);
-            model->Q = (double *)malloc(num_Q * sizeof(double));
-        }
+    ar & num_delay;
+    if (Archive::is_loading::value
+        && (num_time_delay_histo_ords != model->num_time_delay_histo_ords
+            || num_delay != model->num_delay)) {
+        char error[160];
+        snprintf(error, sizeof(error),
+                 "state has %d histogram ordinates and %d delay steps, but this "
+                 "configuration has %d and %d",
+                 num_time_delay_histo_ords, num_delay,
+                 model->num_time_delay_histo_ords, model->num_delay);
+        throw std::runtime_error(error);
     }
-    ar & boost::serialization::make_array(
-        model->time_delay_histogram, model->num_time_delay_histo_ords + 1
-    );
+
+    // The weights come from config too, and the counts matching does not mean the
+    // weights do, so this run's own stand under either mode.
+    archive_array_field(ar, model->time_delay_histogram, model->num_time_delay_histo_ords + 1, false);
+
+    size_t num_Q = model->num_delay + model->num_time_delay_histo_ords + 1;
     ar & boost::serialization::make_array(model->Q, num_Q);
 }
 

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -1,0 +1,134 @@
+extern "C" {
+#include "../include/topmodel.h"
+}
+#include <cstdio>
+#include "../include/bmi_serialization.h"
+
+#include <fstream>
+#include <streambuf>
+#include <sstream>
+
+#include <boost/serialization/serialization.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
+#include "../include/vecbuf.hpp"
+
+
+class TopmodelSerializer {
+    public:
+        TopmodelSerializer(Bmi* bmi)
+            : model((topmodel_model*)bmi->data) {};
+        ~TopmodelSerializer() = default;
+
+    private:
+        friend class boost::serialization::access;
+        topmodel_model* model;
+        template<class Archive>
+        void serialize(Archive& ar, const unsigned int version);
+};
+
+
+template<class Archive>
+void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
+    topmodel_model* model = this->model;
+    ar & model->current_time_step;
+
+    // data summed between runs
+    ar & model->sump; //
+    ar & model->sumae; //
+    ar & model->sumq; //
+    ar & model->sumrz; // reassigned each update; not used for calcs
+    ar & model->sumuz; // reassigned each update; not used for calcs
+
+    // outputs of Update
+    ar & model->Qout; // reassigned each update; not used for calcs
+    ar & model->quz; //
+    ar & model->qb; // reassigned each update; not used for calcs
+    ar & model->qof; //
+    ar & model->p; // reassigned each update; used in calc after assignment
+    ar & model->ep; // reassigned each update; used in calc after assignment
+    ar & model->sbar; // used then reassigned
+
+    // array data that updates in update; counts set in config
+    // these have an actual size 1 larger than the number
+    int num_topodex_values = model->num_topodex_values + 1;
+    ar & boost::serialization::make_array(
+        model->deficit_root_zone, num_topodex_values
+    );
+    ar & boost::serialization::make_array(
+        model->stor_unsat_zone, num_topodex_values
+    );
+    ar & boost::serialization::make_array(
+        model->deficit_local, num_topodex_values
+    );
+    ar & boost::serialization::make_array(
+        model->contrib_area, num_topodex_values
+    );
+    ar & boost::serialization::make_array(
+        model->Q, model->num_time_delay_histo_ords + 1
+    );
+}
+
+
+extern "C" {
+
+/**
+ * Serializes a Topmodel BMI model through boost. Formats the data as binary output for smaller memory impact than text.
+ * It is the responsibility of the caller to free the newly allocated memory if BMI_SUCCESS is returned.
+ * 
+ * @param bmi topmodel BMI model that will be serialized
+ * @param buffer Pointer to a char pointer. The pointer's pointer will be assigned to the serialized data.
+ * @param size_written Pointer to the amount of data that was written to the buffer.
+ * @return int signifiying whether the serialization process completed successfully.
+ */
+const int serialize_topmodel(Bmi* bmi) {
+    TopmodelSerializer serializer(bmi);
+    vecbuf<char> stream;
+    boost::archive::binary_oarchive archive(stream);
+    try {
+        archive << serializer;
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Serializing Topmodel encountered an error: %s\n", e.what());
+        return BMI_FAILURE;
+    }
+    // copy serialized data into topmodel data
+    topmodel_model* model = (topmodel_model*)bmi->data;
+    // clear previous data if it exists
+    if (model->serialized != NULL) {
+        free(model->serialized);
+    }
+    // set size and allocate memory
+    model->serialized_length = stream.size();
+    model->serialized = (char*)malloc(sizeof(char) * model->serialized_length);
+    // make sure memory could be allocated
+    if (model->serialized == NULL) {
+        model->serialized_length = 0;
+        return BMI_FAILURE;
+    }
+    // copy stream data to new allocation
+    memcpy(model->serialized, stream.data(), model->serialized_length);
+    return BMI_SUCCESS;
+}
+
+ /**
+  * Deserializes data into a Topmodel BMI model.
+  * 
+  * @param bmi Topmodel BMI model that will have values inserted into it.
+  * @param buffer Start of data that wil be read as previously serialized state
+  * @return int signifiying whether the serialization process completed successfully.
+  */
+const int deserialize_topmodel(Bmi* bmi, const char* buffer) {
+    TopmodelSerializer serializer(bmi);
+    std::istringstream stream(buffer);
+    boost::archive::binary_iarchive archive(stream);
+    try {
+        archive >> serializer;
+        return BMI_SUCCESS;
+    } catch (const std::exception &e) {
+        fprintf(stderr, "Deserializing Topmodel encountered an error: %s\n", e.what());
+        return BMI_FAILURE;
+    }
+}
+
+}

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -27,10 +27,23 @@ class TopmodelSerializer {
         void serialize(Archive& ar, const unsigned int version);
 };
 
+/* Bump on any change to what serialize() archives, so that older payloads are
+   rejected rather than misread.  Boost stores this in the archive itself. */
+#define TOPMODEL_SERIALIZATION_LAYOUT_VERSION 1
+BOOST_CLASS_VERSION(TopmodelSerializer, TOPMODEL_SERIALIZATION_LAYOUT_VERSION)
+
 
 template<class Archive>
 void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
     topmodel_model* model = this->model;
+    // Check before archiving anything, so a rejected payload leaves state untouched
+    if (Archive::is_loading::value && version != TOPMODEL_SERIALIZATION_LAYOUT_VERSION) {
+        char error[128];
+        snprintf(error, sizeof(error),
+                 "state is layout version %u, but this build expects %d",
+                 version, TOPMODEL_SERIALIZATION_LAYOUT_VERSION);
+        throw std::runtime_error(error);
+    }
     if (model->stand_alone == TRUE) {
         // the number of timesteps makes hindcasting nigh imposible when stand alone
         auto error = "Topmodel serialization is not currently implemented when running stand alone.";
@@ -115,8 +128,9 @@ extern "C" {
 const int serialize_topmodel(Bmi* bmi) {
     TopmodelSerializer serializer(bmi);
     vecbuf<char> stream;
-    boost::archive::binary_oarchive archive(stream);
     try {
+        // Constructing the archive writes the header, so it belongs inside the try
+        boost::archive::binary_oarchive archive(stream);
         archive << serializer;
     } catch (const std::exception& e) {
         fprintf(stderr, "Serializing Topmodel encountered an error: %s\n", e.what());
@@ -157,8 +171,10 @@ const int deserialize_topmodel(Bmi* bmi, char* buffer) {
     memcpy(&size, buffer, sizeof(uint64_t));
     // create stream from data after header
     membuf stream(buffer + sizeof(uint64_t), size);
-    boost::archive::binary_iarchive archive(stream);
     try {
+        // Constructing the archive validates the header, so it belongs inside the
+        // try; otherwise a foreign or corrupt payload escapes as an exception
+        boost::archive::binary_iarchive archive(stream);
         archive >> serializer;
         return BMI_SUCCESS;
     } catch (const std::exception &e) {

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -6,7 +6,6 @@ extern "C" {
 #include "../include/bmi_serialization.h"
 
 #include <stdexcept>
-#include <vector>
 
 #include <boost/serialization/serialization.hpp>
 #include <boost/archive/binary_iarchive.hpp>
@@ -50,18 +49,6 @@ static void archive_field(Archive& ar, T& value, bool apply) {
     }
 }
 
-template<class Archive>
-static void archive_array_field(Archive& ar, double* values, int count, bool apply) {
-    if (Archive::is_saving::value) {
-        ar & boost::serialization::make_array(values, count);
-    } else {
-        std::vector<double> incoming(count);
-        ar & boost::serialization::make_array(incoming.data(), count);
-        if (apply)
-            memcpy(values, incoming.data(), (size_t)count * sizeof(double));
-    }
-}
-
 
 template<class Archive>
 void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
@@ -80,18 +67,19 @@ void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
         fprintf(stderr, "%s\n", error);
         throw std::runtime_error(error);
     }
-    // The clock and the totals below describe the run that wrote the snapshot,
-    // so they carry over only when this run is continuing it.
+    // The clock counts this simulation's steps, so it carries over only when this
+    // run is continuing the one that wrote the snapshot.  Everything below is
+    // applied either way; see topmodel_restore_mode.
     const bool resume = model->restore_mode == TOPMODEL_RESTORE_RESUME;
 
     archive_field(ar, model->current_time_step, resume);
 
     // data summed between runs
-    archive_field(ar, model->sump, resume);
-    archive_field(ar, model->sumae, resume);
-    archive_field(ar, model->sumq, resume);
-    archive_field(ar, model->sumrz, resume); // reassigned each update; not used for calcs
-    archive_field(ar, model->sumuz, resume); // reassigned each update; not used for calcs
+    ar & model->sump; //
+    ar & model->sumae; //
+    ar & model->sumq; //
+    ar & model->sumrz; // reassigned each update; not used for calcs
+    ar & model->sumuz; // reassigned each update; not used for calcs
 
     // outputs of Update
     ar & model->Qout; // reassigned each update; not used for calcs
@@ -120,30 +108,30 @@ void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
         model->contrib_area, model->nstep + 1
     );
 
-    // Channel routing counts come from config, so this run's own values stand.
-    // A snapshot that disagrees describes a different catchment setup and is
-    // refused rather than resized into.
+    // copy the current sizes to detect changes, then archive the model value
     int num_time_delay_histo_ords = model->num_time_delay_histo_ords;
-    ar & num_time_delay_histo_ords;
+    ar & model->num_time_delay_histo_ords;
     int num_delay = model->num_delay;
-    ar & num_delay;
-    if (Archive::is_loading::value
-        && (num_time_delay_histo_ords != model->num_time_delay_histo_ords
-            || num_delay != model->num_delay)) {
-        char error[160];
-        snprintf(error, sizeof(error),
-                 "state has %d histogram ordinates and %d delay steps, but this "
-                 "configuration has %d and %d",
-                 num_time_delay_histo_ords, num_delay,
-                 model->num_time_delay_histo_ords, model->num_delay);
-        throw std::runtime_error(error);
-    }
-
-    // The weights come from config too, and the counts matching does not mean the
-    // weights do, so this run's own stand under either mode.
-    archive_array_field(ar, model->time_delay_histogram, model->num_time_delay_histo_ords + 1, false);
-
+    ar & model->num_delay;
     size_t num_Q = model->num_delay + model->num_time_delay_histo_ords + 1;
+    if (Archive::is_loading::value) {
+        // if loading and array size has changed, reallocate
+        if (num_time_delay_histo_ords != model->num_time_delay_histo_ords) {
+            if (model->time_delay_histogram != NULL)
+                free(model->time_delay_histogram);
+            model->time_delay_histogram = (double *)malloc(
+                (model->num_time_delay_histo_ords + 1) * sizeof(double)
+            );
+        }
+        if (num_delay != model->num_delay || num_time_delay_histo_ords != model->num_time_delay_histo_ords) {
+            if (model->Q != NULL)
+                free(model->Q);
+            model->Q = (double *)malloc(num_Q * sizeof(double));
+        }
+    }
+    ar & boost::serialization::make_array(
+        model->time_delay_histogram, model->num_time_delay_histo_ords + 1
+    );
     ar & boost::serialization::make_array(model->Q, num_Q);
 }
 

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -143,8 +143,6 @@ extern "C" {
  * It is the responsibility of the caller to free the newly allocated memory if BMI_SUCCESS is returned.
  *
  * @param bmi topmodel BMI model that will be serialized
- * @param buffer Pointer to a char pointer. The pointer's pointer will be assigned to the serialized data.
- * @param size_written Pointer to the amount of data that was written to the buffer.
  * @return int signifiying whether the serialization process completed successfully.
  */
 const int serialize_topmodel(Bmi* bmi) {

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -1,6 +1,7 @@
 extern "C" {
 #include "../include/topmodel.h"
 }
+#include <cstdint>
 #include <cstdio>
 #include "../include/bmi_serialization.h"
 
@@ -129,7 +130,7 @@ const int serialize_topmodel(Bmi* bmi) {
     }
     // set size and allocate memory
     uint64_t serialized_size = stream.size();
-    model->serialized_length = serialized_size + sizeof(uint64_t);
+    model->serialized_length = (int)(serialized_size + sizeof(uint64_t));
     model->serialized = (char*)malloc(model->serialized_length);
     // make sure memory could be allocated
     if (model->serialized == NULL) {

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -4,9 +4,7 @@ extern "C" {
 #include <cstdio>
 #include "../include/bmi_serialization.h"
 
-#include <fstream>
-#include <streambuf>
-#include <sstream>
+#include <stdexcept>
 
 #include <boost/serialization/serialization.hpp>
 #include <boost/archive/binary_iarchive.hpp>
@@ -32,6 +30,12 @@ class TopmodelSerializer {
 template<class Archive>
 void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
     topmodel_model* model = this->model;
+    if (model->stand_alone == TRUE) {
+        // the number of timesteps makes hindcasting nigh imposible when stand alone
+        auto error = "Topmodel serialization is not currently implemented when running stand alone.";
+        fprintf(stderr, "%s\n", error);
+        throw std::runtime_error(error);
+    }
     ar & model->current_time_step;
 
     // data summed between runs
@@ -62,12 +66,37 @@ void TopmodelSerializer::serialize(Archive& ar, const unsigned int version) {
     ar & boost::serialization::make_array(
         model->deficit_local, num_topodex_values
     );
+
+    // nsteps will always be 1 for non-stand-alone models
     ar & boost::serialization::make_array(
-        model->contrib_area, num_topodex_values
+        model->contrib_area, model->nstep + 1
     );
+
+    // copy the current sizes to detect changes, then archive the model value
+    int num_time_delay_histo_ords = model->num_time_delay_histo_ords;
+    ar & model->num_time_delay_histo_ords;
+    int num_delay = model->num_delay;
+    ar & model->num_delay;
+    size_t num_Q = model->num_delay + model->num_time_delay_histo_ords + 1;
+    if (Archive::is_loading::value) {
+        // if loading and array size has changed, reallocate
+        if (num_time_delay_histo_ords != model->num_time_delay_histo_ords) {
+            if (model->time_delay_histogram != NULL)
+                free(model->time_delay_histogram);
+            model->time_delay_histogram = (double *)malloc(
+                (model->num_time_delay_histo_ords + 1) * sizeof(double)
+            );
+        }
+        if (num_delay != model->num_delay || num_time_delay_histo_ords != model->num_time_delay_histo_ords) {
+            if (model->Q != NULL)
+                free(model->Q);
+            model->Q = (double *)malloc(num_Q * sizeof(double));
+        }
+    }
     ar & boost::serialization::make_array(
-        model->Q, model->num_time_delay_histo_ords + 1
+        model->time_delay_histogram, model->num_time_delay_histo_ords + 1
     );
+    ar & boost::serialization::make_array(model->Q, num_Q);
 }
 
 
@@ -99,15 +128,17 @@ const int serialize_topmodel(Bmi* bmi) {
         free(model->serialized);
     }
     // set size and allocate memory
-    model->serialized_length = stream.size();
-    model->serialized = (char*)malloc(sizeof(char) * model->serialized_length);
+    uint64_t serialized_size = stream.size();
+    model->serialized_length = serialized_size + sizeof(uint64_t);
+    model->serialized = (char*)malloc(model->serialized_length);
     // make sure memory could be allocated
     if (model->serialized == NULL) {
         model->serialized_length = 0;
         return BMI_FAILURE;
     }
     // copy stream data to new allocation
-    memcpy(model->serialized, stream.data(), model->serialized_length);
+    memcpy(model->serialized, &serialized_size, sizeof(uint64_t));
+    memcpy(model->serialized + sizeof(uint64_t), stream.data(), serialized_size);
     return BMI_SUCCESS;
 }
 
@@ -118,9 +149,13 @@ const int serialize_topmodel(Bmi* bmi) {
   * @param buffer Start of data that wil be read as previously serialized state
   * @return int signifiying whether the serialization process completed successfully.
   */
-const int deserialize_topmodel(Bmi* bmi, const char* buffer) {
+const int deserialize_topmodel(Bmi* bmi, char* buffer) {
     TopmodelSerializer serializer(bmi);
-    std::istringstream stream(buffer);
+    // copy size of data out of header
+    uint64_t size;
+    memcpy(&size, buffer, sizeof(uint64_t));
+    // create stream from data after header
+    membuf stream(buffer + sizeof(uint64_t), size);
     boost::archive::binary_iarchive archive(stream);
     try {
         archive >> serializer;

--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -141,7 +141,7 @@ extern "C" {
 /**
  * Serializes a Topmodel BMI model through boost. Formats the data as binary output for smaller memory impact than text.
  * It is the responsibility of the caller to free the newly allocated memory if BMI_SUCCESS is returned.
- * 
+ *
  * @param bmi topmodel BMI model that will be serialized
  * @param buffer Pointer to a char pointer. The pointer's pointer will be assigned to the serialized data.
  * @param size_written Pointer to the amount of data that was written to the buffer.
@@ -165,8 +165,7 @@ const int serialize_topmodel(Bmi* bmi) {
         free(model->serialized);
     }
     // set size and allocate memory
-    uint64_t serialized_size = stream.size();
-    model->serialized_length = (int)(serialized_size + sizeof(uint64_t));
+    model->serialized_length = (int64_t)stream.size();
     model->serialized = (char*)malloc(model->serialized_length);
     // make sure memory could be allocated
     if (model->serialized == NULL) {
@@ -174,25 +173,21 @@ const int serialize_topmodel(Bmi* bmi) {
         return BMI_FAILURE;
     }
     // copy stream data to new allocation
-    memcpy(model->serialized, &serialized_size, sizeof(uint64_t));
-    memcpy(model->serialized + sizeof(uint64_t), stream.data(), serialized_size);
+    memcpy(model->serialized, stream.data(), model->serialized_length);
     return BMI_SUCCESS;
 }
 
  /**
   * Deserializes data into a Topmodel BMI model.
-  * 
+  *
   * @param bmi Topmodel BMI model that will have values inserted into it.
   * @param buffer Start of data that wil be read as previously serialized state
+  * @param size Bytes of serialized state in buffer
   * @return int signifiying whether the serialization process completed successfully.
   */
-const int deserialize_topmodel(Bmi* bmi, char* buffer) {
+const int deserialize_topmodel(Bmi* bmi, char* buffer, int64_t size) {
     TopmodelSerializer serializer(bmi);
-    // copy size of data out of header
-    uint64_t size;
-    memcpy(&size, buffer, sizeof(uint64_t));
-    // create stream from data after header
-    membuf stream(buffer + sizeof(uint64_t), size);
+    membuf stream(buffer, size);
     try {
         // Constructing the archive validates the header, so it belongs inside the
         // try; otherwise a foreign or corrupt payload escapes as an exception

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -594,6 +594,9 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
     if (strcmp(name, "serialization_create") == 0) {
         strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_size") == 0) {
+        strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
     } else if (strcmp(name, "serialization_state") == 0) {
         strncpy(type, "char", BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
@@ -736,7 +739,7 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
     }
     // special cases for save state
     if (item_count < 1) {
-        if (strcmp(name, "serialization_create") == 0 || strcmp(name, "serialization_free") == 0) {
+        if (strcmp(name, "serialization_create") == 0 || strcmp(name, "serialization_size") == 0 || strcmp(name, "serialization_free") == 0) {
             item_count = 1;
         } else if (strcmp(name, "serialization_state") == 0) {
             topmodel_model* model = (topmodel_model*)self->data;
@@ -942,14 +945,14 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
     }
 
     // serialization commands
-    if (strcmp(name, "serialization_create") == 0) {
-        // create new serialized data
-        if (serialize_topmodel(self) != BMI_SUCCESS)
-            return BMI_FAILURE;
+    if (strcmp(name, "serialization_size") == 0) {
         topmodel_model* topmodel = (topmodel_model*)self->data;
-        *dest = &topmodel->serialized_length;
+        if (topmodel->serialized == NULL)
+            return BMI_FAILURE;
+        *dest = (void*)&topmodel->serialized_length;
         return BMI_SUCCESS;
-    } else if (strcmp(name, "serialization_state") == 0) {
+    }
+    if (strcmp(name, "serialization_state") == 0) {
         topmodel_model* topmodel = (topmodel_model*)self->data;
         if (topmodel->serialized == NULL)
             return BMI_FAILURE;
@@ -1013,6 +1016,11 @@ static int Set_value (Bmi *self, const char *name, void *array)
         model->serialized = NULL;
         model->serialized_length = 0;
         return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_create") == 0) {
+        // create new serialized data
+        if (serialize_topmodel(self) != BMI_SUCCESS)
+            return BMI_FAILURE;
+        return BMI_SUCCESS;
     } else if (strcmp(name, "serialization_state") == 0) {
         if (deserialize_topmodel(self, (char*)array) == BMI_SUCCESS) {
             topmodel_model* model = (topmodel_model*)self->data;
@@ -1025,9 +1033,6 @@ static int Set_value (Bmi *self, const char *name, void *array)
         } else {
             return BMI_FAILURE;
         }
-    } else if (strcmp(name, "serialization_create") == 0) {
-        fprintf(stderr, "topmodel: cannot set a value with \"serialization_create\".\n");
-        return BMI_FAILURE;
     }
 
     if (self->get_value_ptr(self, name, &dest) == BMI_FAILURE)

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -1364,6 +1364,9 @@ topmodel_model * new_bmi_topmodel()  //(void)?
     data->dist_from_outlet = NULL;     // distance from outlet to point on channel with area known
     data->serialized = NULL;           // empty serialized state
     data->serialized_length = 0;
+    // TODO: only a hotstart restore is driven at present; when a resume is also
+    // driven, this needs to become selectable by the caller
+    data->restore_mode = TOPMODEL_RESTORE_HOTSTART;
     return data;
 }
 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -652,6 +652,10 @@ static int Get_var_itemsize (Bmi *self, const char *name, int * size)
         *size = sizeof(long);
         return BMI_SUCCESS;
     }
+    else if (strcmp (type, "int64") == 0) {
+        *size = sizeof(int64_t);
+        return BMI_SUCCESS;
+    }
     else if (strcmp (type, "char") == 0) {
         *size = sizeof(char);
         return BMI_SUCCESS;
@@ -721,10 +725,9 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
     int ser_var = serialization_var_index(name);
     if (ser_var >= 0) {
         int ser_count = serialization_var_item_count[ser_var];
-        // A restore precedes the first capture, so report 0 rather than failing
-        // when no state has been created yet
+        // the length a create captured or a restore declared; 0 before either
         if (ser_count == 0)
-            ser_count = ((topmodel_model *) self->data)->serialized_length;
+            ser_count = (int)((topmodel_model *) self->data)->serialized_length;
         *nbytes = item_size * ser_count;
         return BMI_SUCCESS;
     }
@@ -1010,17 +1013,18 @@ static int Set_value (Bmi *self, const char *name, void *array)
         case SER_VAR_CREATE:
             return serialize_topmodel(self);
         case SER_VAR_STATE:
-            if (deserialize_topmodel(self, (char*)array) == BMI_FAILURE)
+            // the payload carries no length, so a size must have been declared first
+            if (model->serialized_length <= 0)
                 return BMI_FAILURE;
+            if (deserialize_topmodel(self, (char*)array, model->serialized_length) == BMI_FAILURE)
+                return BMI_FAILURE;
+            // the declared length stands; only a buffer left from an earlier save is freed
             if (model->serialized != NULL) {
                 free(model->serialized);
                 model->serialized = NULL;
-                model->serialized_length = 0;
             }
             return BMI_SUCCESS;
-        case SER_VAR_SIZE:
-            // read-only; reports the length set by create
-            return BMI_FAILURE;
+        // size is assigned like any other value
     }
 
     if (self->get_value_ptr(self, name, &dest) == BMI_FAILURE)

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -961,6 +961,10 @@ static int Get_value_at_indices (Bmi *self, const char *name, void *dest, int * 
     void *src = NULL;
     int itemsize = 0;
 
+    // a reserved name is a scalar or an opaque buffer, and the indices below are unchecked
+    if (serialization_var_index(name) >= 0)
+        return BMI_FAILURE;
+
     if (self->get_value_ptr(self, name, &src) == BMI_FAILURE)
         return BMI_FAILURE;
 
@@ -1183,6 +1187,10 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
 {
     void * to = NULL;
     int itemsize = 0;
+
+    // a reserved name is a scalar or an opaque buffer, and the indices below are unchecked
+    if (serialization_var_index(name) >= 0)
+        return BMI_FAILURE;
 
     if (self->get_value_ptr (self, name, &to) == BMI_FAILURE)
         return BMI_FAILURE;

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -1,7 +1,7 @@
 #include "../include/topmodel.h" 
 #include "../include/bmi.h" 
 #include "../include/bmi_topmodel.h"
-
+#include "../include/bmi_serialization.h"
 
 /* BMI Adaption: Max i/o file name length changed from 30 to 256 */
 #define MAX_FILENAME_LENGTH 256
@@ -553,7 +553,10 @@ static int Finalize (Bmi *self)
             fclose(model->output_fptr);
             fclose(model->out_hyd_fptr);
         }
-        
+
+        if (model->serialized != NULL)
+            free(model->serialized);
+
         free(self->data);
     }
     return BMI_SUCCESS;
@@ -586,6 +589,17 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
             strncpy(type, param_var_types[i], BMI_MAX_TYPE_NAME);
             return BMI_SUCCESS;
         }
+    }
+    // save state specials
+    if (strcmp(name, "serialization_create") == 0) {
+        strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_state") == 0) {
+        strncpy(type, "char", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_free") == 0) {
+        strncpy(type, "int", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
     }
     // If we get here, it means the variable name wasn't recognized
     type[0] = '\0';
@@ -640,6 +654,14 @@ static int Get_var_itemsize (Bmi *self, const char *name, int * size)
     }
     else if (strcmp (type, "long") == 0) {
         *size = sizeof(long);
+        return BMI_SUCCESS;
+    }
+    else if (strcmp (type, "char") == 0) {
+        *size = sizeof(char);
+        return BMI_SUCCESS;
+    }
+    else if (strcmp (type, "uint64_t") == 0) {
+        *size = sizeof(uint64_t);
         return BMI_SUCCESS;
     }
     else {
@@ -710,6 +732,20 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
                 item_count = output_var_item_count[i];
                 break;
             }
+        }
+    }
+    // special cases for save state
+    if (item_count < 1) {
+        if (strcmp(name, "serialization_create") == 0 || strcmp(name, "serialization_free") == 0) {
+            item_count = 1;
+        } else if (strcmp(name, "serialization_state") == 0) {
+            topmodel_model* model = (topmodel_model*)self->data;
+            if (model->serialized == NULL){
+                fprintf(stderr, "topmodel: attempting to access a saved state without a state "
+                                "being created on the model.\n");
+                return BMI_FAILURE;
+            }
+            item_count = model->serialized_length;
         }
     }
     if (item_count < 1)
@@ -905,6 +941,22 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
+    // serialization commands
+    if (strcmp(name, "serialization_create") == 0) {
+        // create new serialized data
+        if (serialize_topmodel(self) != BMI_SUCCESS)
+            return BMI_FAILURE;
+        topmodel_model* topmodel = (topmodel_model*)self->data;
+        *dest = &topmodel->serialized_length;
+        return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_state") == 0) {
+        topmodel_model* topmodel = (topmodel_model*)self->data;
+        if (topmodel->serialized == NULL)
+            return BMI_FAILURE;
+        *dest = topmodel->serialized;
+        return BMI_SUCCESS;
+    }
+
     return BMI_FAILURE;
 }
 
@@ -952,6 +1004,31 @@ static int Set_value (Bmi *self, const char *name, void *array)
 {
     void * dest = NULL;
     int nbytes = 0;
+
+    // special cases for serialized data
+    if (strcmp(name, "serialization_free") == 0) {
+        topmodel_model* model = (topmodel_model*)self->data;
+        if (model->serialized != NULL) 
+            free(model->serialized);
+        model->serialized = NULL;
+        model->serialized_length = 0;
+        return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_state") == 0) {
+        if (deserialize_topmodel(self, (char*)array) == BMI_SUCCESS) {
+            topmodel_model* model = (topmodel_model*)self->data;
+            if (model->serialized != NULL) {
+                free(model->serialized);
+                model->serialized = NULL;
+                model->serialized_length = 0;
+            }
+            return BMI_SUCCESS;
+        } else {
+            return BMI_FAILURE;
+        }
+    } else if (strcmp(name, "serialization_create") == 0) {
+        fprintf(stderr, "topmodel: cannot set a value with \"serialization_create\".\n");
+        return BMI_FAILURE;
+    }
 
     if (self->get_value_ptr(self, name, &dest) == BMI_FAILURE)
         return BMI_FAILURE;
@@ -1292,6 +1369,8 @@ topmodel_model * new_bmi_topmodel()  //(void)?
     data->lnaotb = NULL;               // these are the ln(a/tanB) values
     data->cum_dist_area_with_dist = NULL;  // channel cum. distr. of area with distance
     data->dist_from_outlet = NULL;     // distance from outlet to point on channel with area known
+    data->serialized = NULL;           // empty serialized state
+    data->serialized_length = 0;
     return data;
 }
 

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -2,6 +2,7 @@
 #include "../include/bmi.h" 
 #include "../include/bmi_topmodel.h"
 #include "../include/bmi_serialization.h"
+#include "../include/ngen_utilities.h"
 
 /* BMI Adaption: Max i/o file name length changed from 30 to 256 */
 #define MAX_FILENAME_LENGTH 256
@@ -590,18 +591,10 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
             return BMI_SUCCESS;
         }
     }
-    // save state specials
-    if (strcmp(name, "serialization_create") == 0) {
-        strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
-        return BMI_SUCCESS;
-    } else if (strcmp(name, "serialization_size") == 0) {
-        strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
-        return BMI_SUCCESS;
-    } else if (strcmp(name, "serialization_state") == 0) {
-        strncpy(type, "char", BMI_MAX_TYPE_NAME);
-        return BMI_SUCCESS;
-    } else if (strcmp(name, "serialization_free") == 0) {
-        strncpy(type, "int", BMI_MAX_TYPE_NAME);
+    // Then check to see if a serialization protocol variable
+    int ser_var = serialization_var_index(name);
+    if (ser_var >= 0) {
+        strncpy(type, serialization_var_types[ser_var], BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
     }
     // If we get here, it means the variable name wasn't recognized
@@ -663,10 +656,6 @@ static int Get_var_itemsize (Bmi *self, const char *name, int * size)
         *size = sizeof(char);
         return BMI_SUCCESS;
     }
-    else if (strcmp (type, "uint64_t") == 0) {
-        *size = sizeof(uint64_t);
-        return BMI_SUCCESS;
-    }
     else {
         *size = 0;
         return BMI_FAILURE;
@@ -696,6 +685,12 @@ static int Get_var_location (Bmi *self, const char *name, char * location)
 
 static int Get_var_units (Bmi *self, const char *name, char * units)
 {
+    // Serialization protocol variables; this call is the engine's support probe
+    int ser_var = serialization_var_index(name);
+    if (ser_var >= 0) {
+        strncpy(units, serialization_var_units[ser_var], BMI_MAX_UNITS_NAME);
+        return BMI_SUCCESS;
+    }
     // Check to see if in output array first
     for (int i = 0; i < OUTPUT_VAR_NAME_COUNT; i++) {
         if (strcmp(name, output_var_names[i]) == 0) {
@@ -722,6 +717,17 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
     if (item_size_result != BMI_SUCCESS) {
         return BMI_FAILURE;
     }
+    // Serialization protocol variables, which must not fall through to the nstep default
+    int ser_var = serialization_var_index(name);
+    if (ser_var >= 0) {
+        int ser_count = serialization_var_item_count[ser_var];
+        // A restore precedes the first capture, so report 0 rather than failing
+        // when no state has been created yet
+        if (ser_count == 0)
+            ser_count = ((topmodel_model *) self->data)->serialized_length;
+        *nbytes = item_size * ser_count;
+        return BMI_SUCCESS;
+    }
     int item_count = -1;
     for (int i = 0; i < INPUT_VAR_NAME_COUNT; i++) {
         if (strcmp(name, input_var_names[i]) == 0) {
@@ -735,20 +741,6 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
                 item_count = output_var_item_count[i];
                 break;
             }
-        }
-    }
-    // special cases for save state
-    if (item_count < 1) {
-        if (strcmp(name, "serialization_create") == 0 || strcmp(name, "serialization_size") == 0 || strcmp(name, "serialization_free") == 0) {
-            item_count = 1;
-        } else if (strcmp(name, "serialization_state") == 0) {
-            topmodel_model* model = (topmodel_model*)self->data;
-            if (model->serialized == NULL){
-                fprintf(stderr, "topmodel: attempting to access a saved state without a state "
-                                "being created on the model.\n");
-                return BMI_FAILURE;
-            }
-            item_count = model->serialized_length;
         }
     }
     if (item_count < 1)
@@ -944,20 +936,18 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
-    // serialization commands
-    if (strcmp(name, "serialization_size") == 0) {
-        topmodel_model* topmodel = (topmodel_model*)self->data;
-        if (topmodel->serialized == NULL)
-            return BMI_FAILURE;
-        *dest = (void*)&topmodel->serialized_length;
-        return BMI_SUCCESS;
-    }
-    if (strcmp(name, "serialization_state") == 0) {
-        topmodel_model* topmodel = (topmodel_model*)self->data;
-        if (topmodel->serialized == NULL)
-            return BMI_FAILURE;
-        *dest = topmodel->serialized;
-        return BMI_SUCCESS;
+    // serialization commands; create and free are triggers, with no stored value
+    topmodel_model* topmodel = (topmodel_model*)self->data;
+    switch (serialization_var_index(name)) {
+        case SER_VAR_SIZE:
+            // Legitimately 0 until a state is created, which is what a restore sees
+            *dest = (void*)&topmodel->serialized_length;
+            return BMI_SUCCESS;
+        case SER_VAR_STATE:
+            if (topmodel->serialized == NULL)
+                return BMI_FAILURE;
+            *dest = topmodel->serialized;
+            return BMI_SUCCESS;
     }
 
     return BMI_FAILURE;
@@ -1008,31 +998,29 @@ static int Set_value (Bmi *self, const char *name, void *array)
     void * dest = NULL;
     int nbytes = 0;
 
-    // special cases for serialized data
-    if (strcmp(name, "serialization_free") == 0) {
-        topmodel_model* model = (topmodel_model*)self->data;
-        if (model->serialized != NULL) 
-            free(model->serialized);
-        model->serialized = NULL;
-        model->serialized_length = 0;
-        return BMI_SUCCESS;
-    } else if (strcmp(name, "serialization_create") == 0) {
-        // create new serialized data
-        if (serialize_topmodel(self) != BMI_SUCCESS)
-            return BMI_FAILURE;
-        return BMI_SUCCESS;
-    } else if (strcmp(name, "serialization_state") == 0) {
-        if (deserialize_topmodel(self, (char*)array) == BMI_SUCCESS) {
-            topmodel_model* model = (topmodel_model*)self->data;
+    // special cases for serialized data; the value passed to a trigger is ignored
+    topmodel_model* model = (topmodel_model*)self->data;
+    switch (serialization_var_index(name)) {
+        case SER_VAR_FREE:
+            if (model->serialized != NULL)
+                free(model->serialized);
+            model->serialized = NULL;
+            model->serialized_length = 0;
+            return BMI_SUCCESS;
+        case SER_VAR_CREATE:
+            return serialize_topmodel(self);
+        case SER_VAR_STATE:
+            if (deserialize_topmodel(self, (char*)array) == BMI_FAILURE)
+                return BMI_FAILURE;
             if (model->serialized != NULL) {
                 free(model->serialized);
                 model->serialized = NULL;
                 model->serialized_length = 0;
             }
             return BMI_SUCCESS;
-        } else {
+        case SER_VAR_SIZE:
+            // read-only; reports the length set by create
             return BMI_FAILURE;
-        }
     }
 
     if (self->get_value_ptr(self, name, &dest) == BMI_FAILURE)

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -1012,6 +1012,13 @@ static int Set_value (Bmi *self, const char *name, void *array)
             return BMI_SUCCESS;
         case SER_VAR_CREATE:
             return serialize_topmodel(self);
+        case SER_VAR_SIZE:
+            // while a capture is held the length is the buffer's own, so overwriting it
+            // would leave a later read running off the end
+            if (model->serialized != NULL)
+                return BMI_FAILURE;
+            memcpy(&model->serialized_length, array, sizeof(model->serialized_length));
+            return BMI_SUCCESS;
         case SER_VAR_STATE:
             // the payload carries no length, so a size must have been declared first
             if (model->serialized_length <= 0)
@@ -1024,7 +1031,6 @@ static int Set_value (Bmi *self, const char *name, void *array)
                 model->serialized = NULL;
             }
             return BMI_SUCCESS;
-        // size is assigned like any other value
     }
 
     if (self->get_value_ptr(self, name, &dest) == BMI_FAILURE)

--- a/test/main_integration_test_serialization.c
+++ b/test/main_integration_test_serialization.c
@@ -2,11 +2,10 @@
  * Long-run restart equivalence for the ngen BMI serialization protocol.
  *
  * Runs the same forcing sequence three ways -- straight through, with one
- * checkpoint/restart, and with three.  Instantaneous outputs must match exactly at
- * every step; the run integrals restart at each boundary and are checked against
- * the reference's increment since then.  Each restart goes through a file and a
- * brand new BMI instance, with the previous one finalized and freed first, so
- * state left dangling in the old instance shows up rather than being read by luck.
+ * checkpoint/restart, and with three -- and requires every output variable to
+ * match exactly at every step.  Each restart goes through a file and a brand new
+ * BMI instance, with the previous one finalized and freed first, so state left
+ * dangling in the old instance shows up rather than being read by luck.
  *
  * Note what the current fixture cannot reach.  It resolves to num_delay 0 and
  * num_time_delay_histo_ords 1, so Q holds two elements either way and
@@ -21,7 +20,6 @@
  */
 
 #include <assert.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -166,45 +164,16 @@ static void run(const int *restart_after, int n_restarts, double *results) {
     destroy_model(model);
 }
 
-/* TODO: hotstart is the only restore supported at present; a full resume,
-   continuing the same simulation, would carry these across a restart too. */
-static int is_run_integral(const char *name) {
-    return strstr(name, "domain_time_integral_of_precipitation") != NULL
-        || strstr(name, "domain_time_integral_of_evaporation") != NULL
-        || strstr(name, "domain_time_integral_of_runoff") != NULL;
-}
-
-/* Instantaneous outputs must match exactly.  The run integrals restart at each
-   boundary, so they are checked against the reference's increment since that
-   boundary; summing a tail is not bit-identical to differencing two totals, hence
-   the tolerance. */
-static void compare(const char *label, const double *reference, const double *actual,
-                    const int *restart_after, int n_restarts) {
-    int baseline = -1;
-    int next = 0;
+static void compare(const char *label, const double *reference, const double *actual) {
     for (int step = 0; step < n_steps; step++) {
         for (int v = 0; v < n_out; v++) {
             int i = step * n_out + v;
-            if (is_run_integral(out_names[v])) {
-                double base = baseline < 0 ? 0.0 : reference[baseline * n_out + v];
-                double expected = reference[i] - base;
-                double scale = fabs(expected) > 1.0 ? fabs(expected) : 1.0;
-                if (fabs(actual[i] - expected) > 1e-9 * scale) {
-                    printf("   FAIL: %s diverges at step %d, %s: %.17g vs %.17g since the restart\n",
-                           label, step, out_names[v], actual[i], expected);
-                    failures++;
-                    return;
-                }
-            } else if (reference[i] != actual[i]) {
+            if (reference[i] != actual[i]) {
                 printf("   FAIL: %s diverges at step %d, %s: %.17g vs %.17g\n",
                        label, step, out_names[v], actual[i], reference[i]);
                 failures++;
                 return;
             }
-        }
-        if (next < n_restarts && step == restart_after[next]) {
-            baseline = step;
-            next++;
         }
     }
     printf("   %s matches the straight run over %d steps and %d variables\n",
@@ -240,11 +209,11 @@ int main(void) {
 
     printf("\n[2] One restart, after step %d\n", one[0]);
     run(one, 1, one_restart);
-    compare("one restart", straight, one_restart, one, 1);
+    compare("one restart", straight, one_restart);
 
     printf("\n[3] Three restarts, after steps %d, %d and %d\n", three[0], three[1], three[2]);
     run(three, 3, three_restarts);
-    compare("three restarts", straight, three_restarts, three, 3);
+    compare("three restarts", straight, three_restarts);
 
     remove(CHECKPOINT_FILE);
     free(straight);

--- a/test/main_integration_test_serialization.c
+++ b/test/main_integration_test_serialization.c
@@ -20,6 +20,7 @@
  */
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -97,13 +98,14 @@ static void load_output_names(void) {
 
 /* Capture through the engine's sequence and write the payload to a file. */
 static void checkpoint(Bmi *model) {
-    int trigger = 0, size = -1;
+    int trigger = 0;
+    int64_t size = -1;
     if (model->set_value(model, "ngen::serialization_create", &trigger) != BMI_SUCCESS) {
         printf("   FAIL: create failed\n");
         exit(BMI_FAILURE);
     }
     if (model->get_value(model, "ngen::serialization_size", &size) != BMI_SUCCESS || size <= 0) {
-        printf("   FAIL: size read back as %d\n", size);
+        printf("   FAIL: size read back as %lld\n", (long long)size);
         exit(BMI_FAILURE);
     }
     char *payload = (char *)malloc((size_t)size);
@@ -125,7 +127,7 @@ static void restore(Bmi *model) {
     FILE *f = fopen(CHECKPOINT_FILE, "rb");
     assert(f != NULL);
     fseek(f, 0, SEEK_END);
-    long size = ftell(f);
+    int64_t size = ftell(f);
     fseek(f, 0, SEEK_SET);
     char *payload = (char *)malloc((size_t)size);
     assert(payload != NULL);
@@ -133,7 +135,8 @@ static void restore(Bmi *model) {
     fclose(f);
     assert(got == (size_t)size);
 
-    if (model->set_value(model, "ngen::serialization_state", payload) != BMI_SUCCESS) {
+    if (model->set_value(model, "ngen::serialization_size", &size) != BMI_SUCCESS ||
+        model->set_value(model, "ngen::serialization_state", payload) != BMI_SUCCESS) {
         printf("   FAIL: restore failed\n");
         exit(BMI_FAILURE);
     }

--- a/test/main_integration_test_serialization.c
+++ b/test/main_integration_test_serialization.c
@@ -2,10 +2,11 @@
  * Long-run restart equivalence for the ngen BMI serialization protocol.
  *
  * Runs the same forcing sequence three ways -- straight through, with one
- * checkpoint/restart, and with three -- and requires every output variable to
- * match exactly at every step.  Each restart goes through a file and a brand new
- * BMI instance, with the previous one finalized and freed first, so state left
- * dangling in the old instance shows up rather than being read by luck.
+ * checkpoint/restart, and with three.  Instantaneous outputs must match exactly at
+ * every step; the run integrals restart at each boundary and are checked against
+ * the reference's increment since then.  Each restart goes through a file and a
+ * brand new BMI instance, with the previous one finalized and freed first, so
+ * state left dangling in the old instance shows up rather than being read by luck.
  *
  * Note what the current fixture cannot reach.  It resolves to num_delay 0 and
  * num_time_delay_histo_ords 1, so Q holds two elements either way and
@@ -20,6 +21,7 @@
  */
 
 #include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -164,16 +166,45 @@ static void run(const int *restart_after, int n_restarts, double *results) {
     destroy_model(model);
 }
 
-static void compare(const char *label, const double *reference, const double *actual) {
+/* TODO: hotstart is the only restore supported at present; a full resume,
+   continuing the same simulation, would carry these across a restart too. */
+static int is_run_integral(const char *name) {
+    return strstr(name, "domain_time_integral_of_precipitation") != NULL
+        || strstr(name, "domain_time_integral_of_evaporation") != NULL
+        || strstr(name, "domain_time_integral_of_runoff") != NULL;
+}
+
+/* Instantaneous outputs must match exactly.  The run integrals restart at each
+   boundary, so they are checked against the reference's increment since that
+   boundary; summing a tail is not bit-identical to differencing two totals, hence
+   the tolerance. */
+static void compare(const char *label, const double *reference, const double *actual,
+                    const int *restart_after, int n_restarts) {
+    int baseline = -1;
+    int next = 0;
     for (int step = 0; step < n_steps; step++) {
         for (int v = 0; v < n_out; v++) {
             int i = step * n_out + v;
-            if (reference[i] != actual[i]) {
+            if (is_run_integral(out_names[v])) {
+                double base = baseline < 0 ? 0.0 : reference[baseline * n_out + v];
+                double expected = reference[i] - base;
+                double scale = fabs(expected) > 1.0 ? fabs(expected) : 1.0;
+                if (fabs(actual[i] - expected) > 1e-9 * scale) {
+                    printf("   FAIL: %s diverges at step %d, %s: %.17g vs %.17g since the restart\n",
+                           label, step, out_names[v], actual[i], expected);
+                    failures++;
+                    return;
+                }
+            } else if (reference[i] != actual[i]) {
                 printf("   FAIL: %s diverges at step %d, %s: %.17g vs %.17g\n",
                        label, step, out_names[v], actual[i], reference[i]);
                 failures++;
                 return;
             }
+        }
+        if (next < n_restarts && step == restart_after[next]) {
+            baseline = step;
+            next++;
         }
     }
     printf("   %s matches the straight run over %d steps and %d variables\n",
@@ -209,11 +240,11 @@ int main(void) {
 
     printf("\n[2] One restart, after step %d\n", one[0]);
     run(one, 1, one_restart);
-    compare("one restart", straight, one_restart);
+    compare("one restart", straight, one_restart, one, 1);
 
     printf("\n[3] Three restarts, after steps %d, %d and %d\n", three[0], three[1], three[2]);
     run(three, 3, three_restarts);
-    compare("three restarts", straight, three_restarts);
+    compare("three restarts", straight, three_restarts, three, 3);
 
     remove(CHECKPOINT_FILE);
     free(straight);

--- a/test/main_integration_test_serialization.c
+++ b/test/main_integration_test_serialization.c
@@ -1,0 +1,234 @@
+/*
+ * Long-run restart equivalence for the ngen BMI serialization protocol.
+ *
+ * Runs the same forcing sequence three ways -- straight through, with one
+ * checkpoint/restart, and with three -- and requires every output variable to
+ * match exactly at every step.  Each restart goes through a file and a brand new
+ * BMI instance, with the previous one finalized and freed first, so state left
+ * dangling in the old instance shows up rather than being read by luck.
+ *
+ * Note what the current fixture cannot reach.  It resolves to num_delay 0 and
+ * num_time_delay_histo_ords 1, so Q holds two elements either way and
+ * time_delay_histogram is config derived and never written during update.
+ * Mis-sizing Q or dropping the histogram therefore both go undetected here; a
+ * catchment with real channel delay would be needed to cover them.  Dropping
+ * genuinely evolving state, sbar for one, is caught at the first step after a
+ * restart.
+ *
+ * NOTE: run from one level below the repo root (the build dir) -- the .run config
+ * names its inputs relative to cwd, as the other test targets also require.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/bmi.h"
+#include "../include/bmi_topmodel.h"
+
+#define CHECKPOINT_FILE "topmodel_integration_checkpoint.bin"
+
+static const char *forcing_file = REPO_ROOT_DIR "/test/data/inputs.dat";
+static const char *config_file = REPO_ROOT_DIR "/test/data/topmod_unit_test.run";
+
+static int n_steps = 0;
+static double *rain = NULL;
+static double *pe = NULL;
+
+static int n_out = 0;
+static char **out_names = NULL;
+
+static int failures = 0;
+
+static void load_forcing(void) {
+    FILE *f = fopen(forcing_file, "r");
+    if (f == NULL) {
+        printf("   FAIL: could not open %s\n", forcing_file);
+        printf("         (run from one level below the repo root)\n");
+        exit(BMI_FAILURE);
+    }
+    double dt = 0.0;
+    if (fscanf(f, "%d %lf", &n_steps, &dt) != 2) {
+        printf("   FAIL: could not read the header of %s\n", forcing_file);
+        exit(BMI_FAILURE);
+    }
+    rain = (double *)malloc(sizeof(double) * n_steps);
+    pe = (double *)malloc(sizeof(double) * n_steps);
+    assert(rain != NULL && pe != NULL);
+    for (int i = 0; i < n_steps; i++) {
+        double qobs;
+        if (fscanf(f, "%lf %lf %lf", &rain[i], &pe[i], &qobs) != 3) {
+            printf("   FAIL: %s ended after %d of %d records\n", forcing_file, i, n_steps);
+            exit(BMI_FAILURE);
+        }
+    }
+    fclose(f);
+}
+
+static Bmi *make_model(void) {
+    Bmi *model = (Bmi *)malloc(sizeof(Bmi));
+    assert(model != NULL);
+    register_bmi_topmodel(model);
+    if (model->initialize(model, config_file) == BMI_FAILURE) {
+        printf("   FAIL: could not initialize from %s\n", config_file);
+        exit(BMI_FAILURE);
+    }
+    return model;
+}
+
+static void destroy_model(Bmi *model) {
+    model->finalize(model);
+    free(model);
+}
+
+static void load_output_names(void) {
+    Bmi *model = make_model();
+    model->get_output_item_count(model, &n_out);
+    out_names = (char **)malloc(sizeof(char *) * n_out);
+    assert(out_names != NULL);
+    for (int i = 0; i < n_out; i++) {
+        out_names[i] = (char *)malloc(BMI_MAX_VAR_NAME);
+        assert(out_names[i] != NULL);
+    }
+    model->get_output_var_names(model, out_names);
+    destroy_model(model);
+}
+
+/* Capture through the engine's sequence and write the payload to a file. */
+static void checkpoint(Bmi *model) {
+    int trigger = 0, size = -1;
+    if (model->set_value(model, "ngen::serialization_create", &trigger) != BMI_SUCCESS) {
+        printf("   FAIL: create failed\n");
+        exit(BMI_FAILURE);
+    }
+    if (model->get_value(model, "ngen::serialization_size", &size) != BMI_SUCCESS || size <= 0) {
+        printf("   FAIL: size read back as %d\n", size);
+        exit(BMI_FAILURE);
+    }
+    char *payload = (char *)malloc((size_t)size);
+    assert(payload != NULL);
+    if (model->get_value(model, "ngen::serialization_state", payload) != BMI_SUCCESS) {
+        printf("   FAIL: state read failed\n");
+        exit(BMI_FAILURE);
+    }
+    model->set_value(model, "ngen::serialization_free", &trigger);
+
+    FILE *f = fopen(CHECKPOINT_FILE, "wb");
+    assert(f != NULL);
+    fwrite(payload, 1, (size_t)size, f);
+    fclose(f);
+    free(payload);
+}
+
+static void restore(Bmi *model) {
+    FILE *f = fopen(CHECKPOINT_FILE, "rb");
+    assert(f != NULL);
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *payload = (char *)malloc((size_t)size);
+    assert(payload != NULL);
+    size_t got = fread(payload, 1, (size_t)size, f);
+    fclose(f);
+    assert(got == (size_t)size);
+
+    if (model->set_value(model, "ngen::serialization_state", payload) != BMI_SUCCESS) {
+        printf("   FAIL: restore failed\n");
+        exit(BMI_FAILURE);
+    }
+    free(payload);
+}
+
+/* Step through the whole forcing record, restarting after each listed step.
+   Outputs land in results as [step * n_out + variable]. */
+static void run(const int *restart_after, int n_restarts, double *results) {
+    Bmi *model = make_model();
+    int next = 0;
+    for (int step = 0; step < n_steps; step++) {
+        model->set_value(model, "atmosphere_water__liquid_equivalent_precipitation_rate", &rain[step]);
+        model->set_value(model, "water_potential_evaporation_flux", &pe[step]);
+        model->update(model);
+
+        for (int v = 0; v < n_out; v++)
+            model->get_value(model, out_names[v], &results[step * n_out + v]);
+
+        if (next < n_restarts && step == restart_after[next]) {
+            checkpoint(model);
+            destroy_model(model);
+            model = make_model();
+            restore(model);
+            next++;
+        }
+    }
+    destroy_model(model);
+}
+
+static void compare(const char *label, const double *reference, const double *actual) {
+    for (int step = 0; step < n_steps; step++) {
+        for (int v = 0; v < n_out; v++) {
+            int i = step * n_out + v;
+            if (reference[i] != actual[i]) {
+                printf("   FAIL: %s diverges at step %d, %s: %.17g vs %.17g\n",
+                       label, step, out_names[v], actual[i], reference[i]);
+                failures++;
+                return;
+            }
+        }
+    }
+    printf("   %s matches the straight run over %d steps and %d variables\n",
+           label, n_steps, n_out);
+}
+
+int main(void) {
+#ifndef REPO_ROOT_DIR
+    printf("Please set REPO_ROOT_DIR build macro and rebuild test executable\n");
+    return BMI_FAILURE;
+#endif
+
+    printf("\nBEGIN BMI SERIALIZATION INTEGRATION TEST\n");
+    printf("***************************************\n");
+
+    load_forcing();
+    load_output_names();
+    printf("\n%d steps of forcing from %s, %d output variables\n",
+           n_steps, forcing_file, n_out);
+
+    size_t n = (size_t)n_steps * n_out;
+    double *straight = (double *)malloc(sizeof(double) * n);
+    double *one_restart = (double *)malloc(sizeof(double) * n);
+    double *three_restarts = (double *)malloc(sizeof(double) * n);
+    assert(straight != NULL && one_restart != NULL && three_restarts != NULL);
+
+    const int one[1] = {n_steps / 2};
+    const int three[3] = {n_steps / 4, n_steps / 2, (3 * n_steps) / 4};
+
+    printf("\n[1] Straight through\n");
+    run(NULL, 0, straight);
+    printf("   completed %d steps\n", n_steps);
+
+    printf("\n[2] One restart, after step %d\n", one[0]);
+    run(one, 1, one_restart);
+    compare("one restart", straight, one_restart);
+
+    printf("\n[3] Three restarts, after steps %d, %d and %d\n", three[0], three[1], three[2]);
+    run(three, 3, three_restarts);
+    compare("three restarts", straight, three_restarts);
+
+    remove(CHECKPOINT_FILE);
+    free(straight);
+    free(one_restart);
+    free(three_restarts);
+    for (int i = 0; i < n_out; i++) free(out_names[i]);
+    free(out_names);
+    free(rain);
+    free(pe);
+
+    printf("\n***************************************\n");
+    if (failures == 0) {
+        printf("END BMI SERIALIZATION INTEGRATION TEST -- all checks passed\n\n");
+        return BMI_SUCCESS;
+    }
+    printf("END BMI SERIALIZATION INTEGRATION TEST -- %d check(s) FAILED\n\n", failures);
+    return BMI_FAILURE;
+}

--- a/test/main_unit_test_serialization.c
+++ b/test/main_unit_test_serialization.c
@@ -488,6 +488,31 @@ static void test_declared_size_refused_over_a_capture(void) {
     destroy_model(model);
 }
 
+/* Indexed access does no bounds checking, so a reserved name has to be turned away. */
+static void test_indexed_access_declines(void) {
+    printf("\n[15] GetValueAtIndices and SetValueAtIndices decline\n");
+    Bmi *model = make_model();
+    step(model, 4);
+
+    int trigger = 0;
+    /* with a capture held, state resolves to a real buffer rather than declining outright */
+    CHECK(model->set_value(model, "ngen::serialization_create", &trigger) == BMI_SUCCESS,
+          "create failed");
+
+    int inds[1] = {1};
+    char value[sizeof(int64_t)] = {0};
+    for (int i = 0; i < 4; i++) {
+        CHECK(model->get_value_at_indices(model, reserved_names[i], value, inds, 1) == BMI_FAILURE,
+              "get_value_at_indices(%s) succeeded", reserved_names[i]);
+        CHECK(model->set_value_at_indices(model, reserved_names[i], inds, 1, value) == BMI_FAILURE,
+              "set_value_at_indices(%s) succeeded", reserved_names[i]);
+    }
+    printf("   all four decline both calls with a capture held\n");
+
+    model->set_value(model, "ngen::serialization_free", &trigger);
+    destroy_model(model);
+}
+
 int main(void) {
 #ifndef REPO_ROOT_DIR
     printf("Please set REPO_ROOT_DIR build macro and rebuild test executable\n");
@@ -514,6 +539,7 @@ int main(void) {
     test_nbytes_reflects_set_size();
     test_state_without_size_fails();
     test_declared_size_refused_over_a_capture();
+    test_indexed_access_declines();
 
     printf("\n***************************************\n");
     if (failures == 0) {

--- a/test/main_unit_test_serialization.c
+++ b/test/main_unit_test_serialization.c
@@ -10,6 +10,7 @@
  */
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,9 +40,9 @@ static const char *reserved_names[4] = {
 static const char *reserved_units[4] = {
     "ngen::trigger", "ngen::trigger", "bytes", "ngen::opaque"
 };
-static const char *reserved_types[4] = {"int", "int", "int", "char"};
+static const char *reserved_types[4] = {"int", "int", "int64", "char"};
 static const int reserved_itemsizes[4] = {
-    (int)sizeof(int), (int)sizeof(int), (int)sizeof(int), (int)sizeof(char)
+    (int)sizeof(int), (int)sizeof(int), (int)sizeof(int64_t), (int)sizeof(char)
 };
 
 static Bmi *make_model(void) {
@@ -77,12 +78,12 @@ static void step_range(Bmi *model, int from, int to) {
 static void step(Bmi *model, int steps) { step_range(model, 0, steps); }
 
 /* Capture through the sequence the engine drives.  Caller frees *out. */
-static int capture(Bmi *model, char **out, int *out_size) {
+static int capture(Bmi *model, char **out, int64_t *out_size) {
     int trigger = 0;
     if (model->set_value(model, "ngen::serialization_create", &trigger) != BMI_SUCCESS)
         return BMI_FAILURE;
 
-    int size = -1;
+    int64_t size = -1;
     if (model->get_value(model, "ngen::serialization_size", &size) != BMI_SUCCESS)
         return BMI_FAILURE;
     if (size <= 0)
@@ -102,6 +103,13 @@ static int capture(Bmi *model, char **out, int *out_size) {
     *out = buffer;
     *out_size = size;
     return BMI_SUCCESS;
+}
+
+/* Restore through the sequence the engine drives: the byte count, then the bytes */
+static int restore(Bmi *model, char *payload, int64_t size) {
+    if (model->set_value(model, "ngen::serialization_size", &size) != BMI_SUCCESS)
+        return BMI_FAILURE;
+    return model->set_value(model, "ngen::serialization_state", payload);
 }
 
 static void test_units_probe(Bmi *model) {
@@ -213,10 +221,10 @@ static void test_round_trip(void) {
     double saved_deficit = m->deficit_local[0];
 
     char *payload = NULL;
-    int payload_size = 0;
+    int64_t payload_size = 0;
     CHECK(capture(model, &payload, &payload_size) == BMI_SUCCESS, "capture failed");
     if (payload == NULL) { destroy_model(model); return; }
-    printf("   captured %d bytes at step %d\n", payload_size, saved_step);
+    printf("   captured %lld bytes at step %d\n", (long long)payload_size, saved_step);
 
     CHECK(m->current_time_step == saved_step && m->sbar == saved_sbar && m->sumq == saved_sumq,
           "create/free altered computed state");
@@ -225,8 +233,7 @@ static void test_round_trip(void) {
     CHECK(m->current_time_step != saved_step, "model did not advance after capture");
     int diverged_step = m->current_time_step;
 
-    CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_SUCCESS,
-          "restore failed");
+    CHECK(restore(model, payload, payload_size) == BMI_SUCCESS, "restore failed");
 
     CHECK(m->sbar == saved_sbar, "sbar = %g, expected %g", m->sbar, saved_sbar);
     CHECK(m->sumq == saved_sumq, "sumq = %g, expected %g", m->sumq, saved_sumq);
@@ -252,7 +259,7 @@ static void test_restore_matches_uninterrupted(void) {
     Bmi *interrupted = make_model();
     step(interrupted, 4);
     char *payload = NULL;
-    int payload_size = 0;
+    int64_t payload_size = 0;
     if (capture(interrupted, &payload, &payload_size) != BMI_SUCCESS) {
         CHECK(0, "capture failed");
         destroy_model(reference);
@@ -260,8 +267,7 @@ static void test_restore_matches_uninterrupted(void) {
         return;
     }
     step(interrupted, 3);
-    CHECK(interrupted->set_value(interrupted, "ngen::serialization_state", payload) == BMI_SUCCESS,
-          "restore failed");
+    CHECK(restore(interrupted, payload, payload_size) == BMI_SUCCESS, "restore failed");
     step_range(interrupted, 4, 7);
 
     topmodel_model *n = (topmodel_model *)interrupted->data;
@@ -290,18 +296,18 @@ static void test_free_is_safe(void) {
     CHECK(model->set_value(model, "ngen::serialization_free", &trigger) == BMI_SUCCESS,
           "second free failed");
 
-    int size = -1;
+    int64_t size = -1;
     CHECK(model->get_value(model, "ngen::serialization_size", &size) == BMI_SUCCESS,
           "size unreadable after free");
-    CHECK(size == 0, "size = %d after free, expected 0", size);
-    printf("   free before create and twice in a row both leave size = %d\n", size);
+    CHECK(size == 0, "size = %lld after free, expected 0", (long long)size);
+    printf("   free before create and twice in a row both leave size = %lld\n", (long long)size);
 
     destroy_model(model);
 }
 
 /* Offset of Boost's class version field, located from the archive signature so a
    layout change fails loudly rather than silently testing nothing. */
-static int layout_version_offset(const char *payload, int size) {
+static int layout_version_offset(const char *payload, int64_t size) {
     static const char sig[] = "serialization::archive";
     for (int i = 0; i + (int)sizeof(sig) < size; i++) {
         if (memcmp(payload + i, sig, sizeof(sig) - 1) == 0)
@@ -316,7 +322,7 @@ static void test_rejects_bad_payloads(void) {
     step(model, 4);
 
     char *payload = NULL;
-    int payload_size = 0;
+    int64_t payload_size = 0;
     if (capture(model, &payload, &payload_size) != BMI_SUCCESS) {
         CHECK(0, "capture failed");
         destroy_model(model);
@@ -333,7 +339,7 @@ static void test_rejects_bad_payloads(void) {
 
     memcpy(corrupt, payload, (size_t)payload_size);
     corrupt[sig_at - 20] = (char)(corrupt[sig_at - 20] + 1);
-    CHECK(model->set_value(model, "ngen::serialization_state", corrupt) == BMI_FAILURE,
+    CHECK(restore(model, corrupt, payload_size) == BMI_FAILURE,
           "a payload with a corrupted signature was accepted");
     CHECK(m->sbar == sbar_before, "a rejected payload altered model state");
 
@@ -343,7 +349,7 @@ static void test_rejects_bad_payloads(void) {
               sig_at, (int)payload[sig_at]);
         memcpy(corrupt, payload, (size_t)payload_size);
         corrupt[sig_at] = (char)(corrupt[sig_at] + 1);
-        CHECK(model->set_value(model, "ngen::serialization_state", corrupt) == BMI_FAILURE,
+        CHECK(restore(model, corrupt, payload_size) == BMI_FAILURE,
               "a payload with an unknown layout version was accepted");
         CHECK(m->sbar == sbar_before, "a rejected payload altered model state");
     }
@@ -367,7 +373,7 @@ static void test_resume_mode_applies_the_clock(void) {
     int saved_step = m->current_time_step;
 
     char *payload = NULL;
-    int payload_size = 0;
+    int64_t payload_size = 0;
     if (capture(model, &payload, &payload_size) != BMI_SUCCESS) {
         CHECK(0, "capture failed");
         destroy_model(model);
@@ -376,11 +382,72 @@ static void test_resume_mode_applies_the_clock(void) {
     step(model, 3);
 
     m->restore_mode = TOPMODEL_RESTORE_RESUME;
-    CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_SUCCESS,
-          "restore failed");
+    CHECK(restore(model, payload, payload_size) == BMI_SUCCESS, "restore failed");
     CHECK(m->current_time_step == saved_step,
           "current_time_step = %d, expected the snapshot's %d", m->current_time_step, saved_step);
     printf("   clock taken from the snapshot at step %d\n", m->current_time_step);
+
+    free(payload);
+    destroy_model(model);
+}
+
+static void test_size_is_settable(void) {
+    printf("\n[11] Size can be set, and reads back\n");
+    Bmi *model = make_model();
+
+    int64_t declared = 4096;
+    CHECK(model->set_value(model, "ngen::serialization_size", &declared) == BMI_SUCCESS,
+          "size is not settable; a restore cannot declare its byte count");
+
+    int64_t reported = -1;
+    CHECK(model->get_value(model, "ngen::serialization_size", &reported) == BMI_SUCCESS,
+          "size unreadable after being set");
+    CHECK(reported == declared, "size = %lld, expected %lld",
+          (long long)reported, (long long)declared);
+    printf("   set %lld, read back %lld\n", (long long)declared, (long long)reported);
+
+    destroy_model(model);
+}
+
+static void test_nbytes_reflects_set_size(void) {
+    printf("\n[12] GetVarNbytes(state) reports a declared size\n");
+    Bmi *model = make_model();
+
+    int64_t declared = 4096;
+    CHECK(model->set_value(model, "ngen::serialization_size", &declared) == BMI_SUCCESS,
+          "size is not settable");
+
+    int nbytes = -1;
+    CHECK(model->get_var_nbytes(model, "ngen::serialization_state", &nbytes) == BMI_SUCCESS,
+          "get_var_nbytes(state) failed");
+    CHECK(nbytes == (int)declared, "nbytes = %d, expected %lld",
+          nbytes, (long long)declared);
+    printf("   nbytes = %d with %lld declared\n", nbytes, (long long)declared);
+
+    destroy_model(model);
+}
+
+/* The payload carries no length of its own, so undeclared bytes are unreadable. */
+static void test_state_without_size_fails(void) {
+    printf("\n[13] State with no declared size is rejected\n");
+    Bmi *model = make_model();
+    step(model, 4);
+
+    char *payload = NULL;
+    int64_t payload_size = 0;
+    if (capture(model, &payload, &payload_size) != BMI_SUCCESS) {
+        CHECK(0, "capture failed");
+        destroy_model(model);
+        return;
+    }
+
+    /* capture ends on free, which clears the size along with the buffer */
+    topmodel_model *m = (topmodel_model *)model->data;
+    double sbar_before = m->sbar;
+    CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_FAILURE,
+          "state was accepted with no size declared");
+    CHECK(m->sbar == sbar_before, "a rejected payload altered model state");
+    printf("   %lld bytes turned away with no size declared\n", (long long)payload_size);
 
     free(payload);
     destroy_model(model);
@@ -408,6 +475,9 @@ int main(void) {
     test_free_is_safe();
     test_rejects_bad_payloads();
     test_resume_mode_applies_the_clock();
+    test_size_is_settable();
+    test_nbytes_reflects_set_size();
+    test_state_without_size_fails();
 
     printf("\n***************************************\n");
     if (failures == 0) {

--- a/test/main_unit_test_serialization.c
+++ b/test/main_unit_test_serialization.c
@@ -198,6 +198,11 @@ static void test_spatial_calls_decline(Bmi *model) {
     printf("   all four decline both calls\n");
 }
 
+/* TODO: hotstart is the only restore supported at present; a full resume,
+   continuing the same simulation, will need its own coverage here. */
+
+/* A restore is a hotstart: physical state carries over, while the clock and the
+   run integrals stay with the run that is doing the restoring. */
 static void test_round_trip(void) {
     printf("\n[6] Save, diverge, restore\n");
     Bmi *model = make_model();
@@ -205,7 +210,7 @@ static void test_round_trip(void) {
 
     topmodel_model *m = (topmodel_model *)model->data;
     int saved_step = m->current_time_step;
-    double saved_sbar = m->sbar, saved_sumq = m->sumq, saved_sump = m->sump;
+    double saved_sbar = m->sbar, saved_sumq = m->sumq;
     double saved_deficit = m->deficit_local[0];
 
     char *payload = NULL;
@@ -219,17 +224,21 @@ static void test_round_trip(void) {
 
     step(model, 3);
     CHECK(m->current_time_step != saved_step, "model did not advance after capture");
+    int diverged_step = m->current_time_step;
+    double diverged_sumq = m->sumq, diverged_sump = m->sump;
 
     CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_SUCCESS,
           "restore failed");
-    CHECK(m->current_time_step == saved_step,
-          "current_time_step = %d, expected %d", m->current_time_step, saved_step);
+
     CHECK(m->sbar == saved_sbar, "sbar = %g, expected %g", m->sbar, saved_sbar);
-    CHECK(m->sumq == saved_sumq, "sumq = %g, expected %g", m->sumq, saved_sumq);
-    CHECK(m->sump == saved_sump, "sump = %g, expected %g", m->sump, saved_sump);
     CHECK(m->deficit_local[0] == saved_deficit,
           "deficit_local[0] = %g, expected %g", m->deficit_local[0], saved_deficit);
-    printf("   restored to step %d\n", m->current_time_step);
+
+    CHECK(m->current_time_step == diverged_step,
+          "restore moved the clock to %d; a hotstart keeps its own", m->current_time_step);
+    CHECK(m->sumq == diverged_sumq && m->sump == diverged_sump,
+          "restore replaced the run integrals; a hotstart keeps its own");
+    printf("   physical state restored, clock left at step %d\n", m->current_time_step);
 
     free(payload);
     destroy_model(model);
@@ -240,7 +249,7 @@ static void test_restore_matches_uninterrupted(void) {
     Bmi *reference = make_model();
     step(reference, 7);
     topmodel_model *r = (topmodel_model *)reference->data;
-    double ref_sbar = r->sbar, ref_sumq = r->sumq, ref_Qout = r->Qout;
+    double ref_sbar = r->sbar, ref_Qout = r->Qout;
 
     Bmi *interrupted = make_model();
     step(interrupted, 4);
@@ -257,11 +266,12 @@ static void test_restore_matches_uninterrupted(void) {
           "restore failed");
     step_range(interrupted, 4, 7);
 
+    // TODO: hotstart is the only restore supported at present; a full resume,
+    // continuing the same simulation, will need its own coverage here.
     topmodel_model *n = (topmodel_model *)interrupted->data;
     CHECK(n->sbar == ref_sbar, "sbar = %g, uninterrupted gave %g", n->sbar, ref_sbar);
-    CHECK(n->sumq == ref_sumq, "sumq = %g, uninterrupted gave %g", n->sumq, ref_sumq);
     CHECK(n->Qout == ref_Qout, "Qout = %g, uninterrupted gave %g", n->Qout, ref_Qout);
-    printf("   sbar=%g sumq=%g Qout=%g in both runs\n", n->sbar, n->sumq, n->Qout);
+    printf("   sbar=%g Qout=%g in both runs\n", n->sbar, n->Qout);
 
     free(payload);
     destroy_model(reference);
@@ -348,6 +358,38 @@ static void test_rejects_bad_payloads(void) {
     destroy_model(model);
 }
 
+/* The mode is fixed at hotstart today, so this covers the other branch of the
+   restore and keeps it from quietly becoming dead code. */
+static void test_resume_mode_applies_run_state(void) {
+    printf("\n[10] Resume mode applies the clock and run integrals\n");
+    Bmi *model = make_model();
+    step(model, 4);
+
+    topmodel_model *m = (topmodel_model *)model->data;
+    int saved_step = m->current_time_step;
+    double saved_sumq = m->sumq;
+
+    char *payload = NULL;
+    int payload_size = 0;
+    if (capture(model, &payload, &payload_size) != BMI_SUCCESS) {
+        CHECK(0, "capture failed");
+        destroy_model(model);
+        return;
+    }
+    step(model, 3);
+
+    m->restore_mode = TOPMODEL_RESTORE_RESUME;
+    CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_SUCCESS,
+          "restore failed");
+    CHECK(m->current_time_step == saved_step,
+          "current_time_step = %d, expected the snapshot's %d", m->current_time_step, saved_step);
+    CHECK(m->sumq == saved_sumq, "sumq = %g, expected the snapshot's %g", m->sumq, saved_sumq);
+    printf("   clock and integrals taken from the snapshot at step %d\n", m->current_time_step);
+
+    free(payload);
+    destroy_model(model);
+}
+
 int main(void) {
 #ifndef REPO_ROOT_DIR
     printf("Please set REPO_ROOT_DIR build macro and rebuild test executable\n");
@@ -369,6 +411,7 @@ int main(void) {
     test_restore_matches_uninterrupted();
     test_free_is_safe();
     test_rejects_bad_payloads();
+    test_resume_mode_applies_run_state();
 
     printf("\n***************************************\n");
     if (failures == 0) {

--- a/test/main_unit_test_serialization.c
+++ b/test/main_unit_test_serialization.c
@@ -453,6 +453,41 @@ static void test_state_without_size_fails(void) {
     destroy_model(model);
 }
 
+/* Declaring a size over a held capture would leave the length past the buffer's end. */
+static void test_declared_size_refused_over_a_capture(void) {
+    printf("\n[14] A size declared over a held capture is refused\n");
+    Bmi *model = make_model();
+    step(model, 4);
+
+    int trigger = 0;
+    CHECK(model->set_value(model, "ngen::serialization_create", &trigger) == BMI_SUCCESS,
+          "create failed");
+
+    int64_t captured = -1;
+    model->get_value(model, "ngen::serialization_size", &captured);
+
+    int64_t declared = captured + 100000;
+    CHECK(model->set_value(model, "ngen::serialization_size", &declared) == BMI_FAILURE,
+          "a size was accepted while a capture was held");
+
+    int64_t reported = -1;
+    model->get_value(model, "ngen::serialization_size", &reported);
+    CHECK(reported == captured, "size = %lld after a refused %lld, expected %lld",
+          (long long)reported, (long long)declared, (long long)captured);
+
+    /* exactly the capture's length, so an overread faults rather than going unnoticed */
+    char *buffer = (char *)malloc((size_t)captured);
+    assert(buffer != NULL);
+    CHECK(model->get_value(model, "ngen::serialization_state", buffer) == BMI_SUCCESS,
+          "state unreadable after a refused size");
+    printf("   %lld refused, capture still reads %lld\n",
+           (long long)declared, (long long)captured);
+
+    free(buffer);
+    model->set_value(model, "ngen::serialization_free", &trigger);
+    destroy_model(model);
+}
+
 int main(void) {
 #ifndef REPO_ROOT_DIR
     printf("Please set REPO_ROOT_DIR build macro and rebuild test executable\n");
@@ -478,6 +513,7 @@ int main(void) {
     test_size_is_settable();
     test_nbytes_reflects_set_size();
     test_state_without_size_fails();
+    test_declared_size_refused_over_a_capture();
 
     printf("\n***************************************\n");
     if (failures == 0) {

--- a/test/main_unit_test_serialization.c
+++ b/test/main_unit_test_serialization.c
@@ -1,0 +1,380 @@
+/*
+ * Conformance and round-trip tests for the ngen BMI serialization protocol.
+ *
+ * The static checks reproduce the host engine's support probe, which is a
+ * GetVarUnits call on each reserved name compared exactly against the protocol's
+ * reserved unit strings.
+ *
+ * NOTE: run from one level below the repo root (the build dir) -- the .run config
+ * names its inputs relative to cwd, as simple_unit_tests also requires.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/bmi.h"
+#include "../include/bmi_topmodel.h"
+#include "../include/topmodel.h"
+
+#define CHECK(cond, ...)          \
+    do {                          \
+        if (!(cond)) {            \
+            printf("   FAIL: ");  \
+            printf(__VA_ARGS__);  \
+            printf("\n");         \
+            failures++;           \
+        }                         \
+    } while (0)
+
+static int failures = 0;
+
+/* Spelled out rather than read from ngen_utilities.h, so that a wrong table is
+   caught instead of agreeing with itself. */
+static const char *reserved_names[4] = {
+    "ngen::serialization_create", "ngen::serialization_free",
+    "ngen::serialization_size",   "ngen::serialization_state"
+};
+static const char *reserved_units[4] = {
+    "ngen::trigger", "ngen::trigger", "bytes", "ngen::opaque"
+};
+static const char *reserved_types[4] = {"int", "int", "int", "char"};
+static const int reserved_itemsizes[4] = {
+    (int)sizeof(int), (int)sizeof(int), (int)sizeof(int), (int)sizeof(char)
+};
+
+static Bmi *make_model(void) {
+    Bmi *model = (Bmi *)malloc(sizeof(Bmi));
+    assert(model != NULL);
+    register_bmi_topmodel(model);
+
+    const char *cfg_file = REPO_ROOT_DIR "/test/data/topmod_unit_test.run";
+    if (model->initialize(model, cfg_file) == BMI_FAILURE) {
+        printf("   FAIL: could not initialize from %s\n", cfg_file);
+        printf("         (run from one level below the repo root)\n");
+        exit(BMI_FAILURE);
+    }
+    return model;
+}
+
+static void destroy_model(Bmi *model) {
+    model->finalize(model);
+    free(model);
+}
+
+/* Deterministic forcings, so two runs over the same indices agree exactly */
+static void step_range(Bmi *model, int from, int to) {
+    for (int i = from; i < to; i++) {
+        double precip = 0.001 * (i + 1);
+        double pet = 0.0005;
+        model->set_value(model, "atmosphere_water__liquid_equivalent_precipitation_rate", &precip);
+        model->set_value(model, "water_potential_evaporation_flux", &pet);
+        model->update(model);
+    }
+}
+
+static void step(Bmi *model, int steps) { step_range(model, 0, steps); }
+
+/* Capture through the sequence the engine drives.  Caller frees *out. */
+static int capture(Bmi *model, char **out, int *out_size) {
+    int trigger = 0;
+    if (model->set_value(model, "ngen::serialization_create", &trigger) != BMI_SUCCESS)
+        return BMI_FAILURE;
+
+    int size = -1;
+    if (model->get_value(model, "ngen::serialization_size", &size) != BMI_SUCCESS)
+        return BMI_FAILURE;
+    if (size <= 0)
+        return BMI_FAILURE;
+
+    char *buffer = (char *)malloc((size_t)size);
+    assert(buffer != NULL);
+    if (model->get_value(model, "ngen::serialization_state", buffer) != BMI_SUCCESS) {
+        free(buffer);
+        return BMI_FAILURE;
+    }
+    if (model->set_value(model, "ngen::serialization_free", &trigger) != BMI_SUCCESS) {
+        free(buffer);
+        return BMI_FAILURE;
+    }
+
+    *out = buffer;
+    *out_size = size;
+    return BMI_SUCCESS;
+}
+
+static void test_units_probe(Bmi *model) {
+    printf("\n[1] GetVarUnits support probe\n");
+    for (int i = 0; i < 4; i++) {
+        char units[BMI_MAX_UNITS_NAME];
+        memset(units, 0, sizeof(units));
+        CHECK(model->get_var_units(model, reserved_names[i], units) == BMI_SUCCESS,
+              "get_var_units(%s) failed; the engine's probe disables the protocol here",
+              reserved_names[i]);
+        CHECK(strcmp(units, reserved_units[i]) == 0,
+              "get_var_units(%s) = \"%s\", expected \"%s\"",
+              reserved_names[i], units, reserved_units[i]);
+        printf("   %s -> \"%s\"\n", reserved_names[i], units);
+    }
+}
+
+static void test_introspection(Bmi *model) {
+    printf("\n[2] GetVarType, GetVarItemsize and GetVarNbytes resolve\n");
+    for (int i = 0; i < 4; i++) {
+        char type[BMI_MAX_TYPE_NAME];
+        int itemsize = -1, nbytes = -1;
+        memset(type, 0, sizeof(type));
+
+        CHECK(model->get_var_type(model, reserved_names[i], type) == BMI_SUCCESS,
+              "get_var_type(%s) failed", reserved_names[i]);
+        CHECK(strcmp(type, reserved_types[i]) == 0,
+              "get_var_type(%s) = \"%s\", expected \"%s\"",
+              reserved_names[i], type, reserved_types[i]);
+        CHECK(model->get_var_itemsize(model, reserved_names[i], &itemsize) == BMI_SUCCESS,
+              "get_var_itemsize(%s) failed", reserved_names[i]);
+        CHECK(itemsize == reserved_itemsizes[i],
+              "get_var_itemsize(%s) = %d, expected %d",
+              reserved_names[i], itemsize, reserved_itemsizes[i]);
+        CHECK(model->get_var_nbytes(model, reserved_names[i], &nbytes) == BMI_SUCCESS,
+              "get_var_nbytes(%s) failed", reserved_names[i]);
+        printf("   %s -> type=%s itemsize=%d nbytes=%d\n",
+               reserved_names[i], type, itemsize, nbytes);
+    }
+}
+
+static void test_nbytes_before_create(Bmi *model) {
+    printf("\n[3] GetVarNbytes(state) resolves before any create\n");
+    int nbytes = -1;
+    CHECK(model->get_var_nbytes(model, "ngen::serialization_state", &nbytes) == BMI_SUCCESS,
+          "get_var_nbytes(state) failed with no state held; a restore precedes the first create");
+    CHECK(nbytes == 0, "expected 0 bytes with no state held, got %d", nbytes);
+    printf("   nbytes with no state held = %d\n", nbytes);
+}
+
+static void test_names_not_enumerated(Bmi *model) {
+    printf("\n[4] Reserved names absent from the item lists\n");
+    int count_in = 0, count_out = 0;
+    model->get_input_item_count(model, &count_in);
+    model->get_output_item_count(model, &count_out);
+
+    char **names_in = (char **)malloc(sizeof(char *) * count_in);
+    char **names_out = (char **)malloc(sizeof(char *) * count_out);
+    assert(names_in != NULL && names_out != NULL);
+    for (int i = 0; i < count_in; i++)
+        names_in[i] = (char *)malloc(BMI_MAX_VAR_NAME);
+    for (int i = 0; i < count_out; i++)
+        names_out[i] = (char *)malloc(BMI_MAX_VAR_NAME);
+
+    model->get_input_var_names(model, names_in);
+    model->get_output_var_names(model, names_out);
+
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < count_in; j++)
+            CHECK(strcmp(names_in[j], reserved_names[i]) != 0,
+                  "%s is in GetInputVarNames", reserved_names[i]);
+        for (int j = 0; j < count_out; j++)
+            CHECK(strcmp(names_out[j], reserved_names[i]) != 0,
+                  "%s is in GetOutputVarNames", reserved_names[i]);
+    }
+    printf("   checked %d input and %d output names\n", count_in, count_out);
+
+    for (int i = 0; i < count_in; i++) free(names_in[i]);
+    for (int i = 0; i < count_out; i++) free(names_out[i]);
+    free(names_in);
+    free(names_out);
+}
+
+static void test_spatial_calls_decline(Bmi *model) {
+    printf("\n[5] GetVarGrid and GetVarLocation decline\n");
+    for (int i = 0; i < 4; i++) {
+        int grid;
+        char location[BMI_MAX_LOCATION_NAME];
+        CHECK(model->get_var_grid(model, reserved_names[i], &grid) == BMI_FAILURE,
+              "get_var_grid(%s) succeeded", reserved_names[i]);
+        CHECK(model->get_var_location(model, reserved_names[i], location) == BMI_FAILURE,
+              "get_var_location(%s) succeeded", reserved_names[i]);
+    }
+    printf("   all four decline both calls\n");
+}
+
+static void test_round_trip(void) {
+    printf("\n[6] Save, diverge, restore\n");
+    Bmi *model = make_model();
+    step(model, 4);
+
+    topmodel_model *m = (topmodel_model *)model->data;
+    int saved_step = m->current_time_step;
+    double saved_sbar = m->sbar, saved_sumq = m->sumq, saved_sump = m->sump;
+    double saved_deficit = m->deficit_local[0];
+
+    char *payload = NULL;
+    int payload_size = 0;
+    CHECK(capture(model, &payload, &payload_size) == BMI_SUCCESS, "capture failed");
+    if (payload == NULL) { destroy_model(model); return; }
+    printf("   captured %d bytes at step %d\n", payload_size, saved_step);
+
+    CHECK(m->current_time_step == saved_step && m->sbar == saved_sbar && m->sumq == saved_sumq,
+          "create/free altered computed state");
+
+    step(model, 3);
+    CHECK(m->current_time_step != saved_step, "model did not advance after capture");
+
+    CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_SUCCESS,
+          "restore failed");
+    CHECK(m->current_time_step == saved_step,
+          "current_time_step = %d, expected %d", m->current_time_step, saved_step);
+    CHECK(m->sbar == saved_sbar, "sbar = %g, expected %g", m->sbar, saved_sbar);
+    CHECK(m->sumq == saved_sumq, "sumq = %g, expected %g", m->sumq, saved_sumq);
+    CHECK(m->sump == saved_sump, "sump = %g, expected %g", m->sump, saved_sump);
+    CHECK(m->deficit_local[0] == saved_deficit,
+          "deficit_local[0] = %g, expected %g", m->deficit_local[0], saved_deficit);
+    printf("   restored to step %d\n", m->current_time_step);
+
+    free(payload);
+    destroy_model(model);
+}
+
+static void test_restore_matches_uninterrupted(void) {
+    printf("\n[7] Restored run matches an uninterrupted one\n");
+    Bmi *reference = make_model();
+    step(reference, 7);
+    topmodel_model *r = (topmodel_model *)reference->data;
+    double ref_sbar = r->sbar, ref_sumq = r->sumq, ref_Qout = r->Qout;
+
+    Bmi *interrupted = make_model();
+    step(interrupted, 4);
+    char *payload = NULL;
+    int payload_size = 0;
+    if (capture(interrupted, &payload, &payload_size) != BMI_SUCCESS) {
+        CHECK(0, "capture failed");
+        destroy_model(reference);
+        destroy_model(interrupted);
+        return;
+    }
+    step(interrupted, 3);
+    CHECK(interrupted->set_value(interrupted, "ngen::serialization_state", payload) == BMI_SUCCESS,
+          "restore failed");
+    step_range(interrupted, 4, 7);
+
+    topmodel_model *n = (topmodel_model *)interrupted->data;
+    CHECK(n->sbar == ref_sbar, "sbar = %g, uninterrupted gave %g", n->sbar, ref_sbar);
+    CHECK(n->sumq == ref_sumq, "sumq = %g, uninterrupted gave %g", n->sumq, ref_sumq);
+    CHECK(n->Qout == ref_Qout, "Qout = %g, uninterrupted gave %g", n->Qout, ref_Qout);
+    printf("   sbar=%g sumq=%g Qout=%g in both runs\n", n->sbar, n->sumq, n->Qout);
+
+    free(payload);
+    destroy_model(reference);
+    destroy_model(interrupted);
+}
+
+static void test_free_is_safe(void) {
+    printf("\n[8] free is safe whenever it is issued\n");
+    Bmi *model = make_model();
+    step(model, 2);
+    int trigger = 0;
+
+    CHECK(model->set_value(model, "ngen::serialization_free", &trigger) == BMI_SUCCESS,
+          "free before any create failed");
+    CHECK(model->set_value(model, "ngen::serialization_create", &trigger) == BMI_SUCCESS,
+          "create failed");
+    CHECK(model->set_value(model, "ngen::serialization_free", &trigger) == BMI_SUCCESS,
+          "first free failed");
+    CHECK(model->set_value(model, "ngen::serialization_free", &trigger) == BMI_SUCCESS,
+          "second free failed");
+
+    int size = -1;
+    CHECK(model->get_value(model, "ngen::serialization_size", &size) == BMI_SUCCESS,
+          "size unreadable after free");
+    CHECK(size == 0, "size = %d after free, expected 0", size);
+    printf("   free before create and twice in a row both leave size = %d\n", size);
+
+    destroy_model(model);
+}
+
+/* Offset of Boost's class version field, located from the archive signature so a
+   layout change fails loudly rather than silently testing nothing. */
+static int layout_version_offset(const char *payload, int size) {
+    static const char sig[] = "serialization::archive";
+    for (int i = 0; i + (int)sizeof(sig) < size; i++) {
+        if (memcmp(payload + i, sig, sizeof(sig) - 1) == 0)
+            return i + (int)(sizeof(sig) - 1) + 11;
+    }
+    return -1;
+}
+
+static void test_rejects_bad_payloads(void) {
+    printf("\n[9] Corrupt and stale payloads are rejected\n");
+    Bmi *model = make_model();
+    step(model, 4);
+
+    char *payload = NULL;
+    int payload_size = 0;
+    if (capture(model, &payload, &payload_size) != BMI_SUCCESS) {
+        CHECK(0, "capture failed");
+        destroy_model(model);
+        return;
+    }
+
+    topmodel_model *m = (topmodel_model *)model->data;
+    double sbar_before = m->sbar;
+    char *corrupt = (char *)malloc((size_t)payload_size);
+    assert(corrupt != NULL);
+
+    int sig_at = layout_version_offset(payload, payload_size);
+    CHECK(sig_at > 0, "could not locate the archive signature in the payload");
+
+    memcpy(corrupt, payload, (size_t)payload_size);
+    corrupt[sig_at - 20] = (char)(corrupt[sig_at - 20] + 1);
+    CHECK(model->set_value(model, "ngen::serialization_state", corrupt) == BMI_FAILURE,
+          "a payload with a corrupted signature was accepted");
+    CHECK(m->sbar == sbar_before, "a rejected payload altered model state");
+
+    if (sig_at > 0) {
+        CHECK(payload[sig_at] == 1,
+              "expected layout version 1 at offset %d, found %d; Boost's archive layout moved",
+              sig_at, (int)payload[sig_at]);
+        memcpy(corrupt, payload, (size_t)payload_size);
+        corrupt[sig_at] = (char)(corrupt[sig_at] + 1);
+        CHECK(model->set_value(model, "ngen::serialization_state", corrupt) == BMI_FAILURE,
+              "a payload with an unknown layout version was accepted");
+        CHECK(m->sbar == sbar_before, "a rejected payload altered model state");
+    }
+
+    printf("   corrupted signature and layout version both rejected\n");
+
+    free(corrupt);
+    free(payload);
+    destroy_model(model);
+}
+
+int main(void) {
+#ifndef REPO_ROOT_DIR
+    printf("Please set REPO_ROOT_DIR build macro and rebuild test executable\n");
+    return BMI_FAILURE;
+#endif
+
+    printf("\nBEGIN BMI SERIALIZATION CONFORMANCE TEST\n");
+    printf("***************************************\n");
+
+    Bmi *model = make_model();
+    test_units_probe(model);
+    test_introspection(model);
+    test_nbytes_before_create(model);
+    test_names_not_enumerated(model);
+    test_spatial_calls_decline(model);
+    destroy_model(model);
+
+    test_round_trip();
+    test_restore_matches_uninterrupted();
+    test_free_is_safe();
+    test_rejects_bad_payloads();
+
+    printf("\n***************************************\n");
+    if (failures == 0) {
+        printf("END BMI SERIALIZATION CONFORMANCE TEST -- all checks passed\n\n");
+        return BMI_SUCCESS;
+    }
+    printf("END BMI SERIALIZATION CONFORMANCE TEST -- %d check(s) FAILED\n\n", failures);
+    return BMI_FAILURE;
+}

--- a/test/main_unit_test_serialization.c
+++ b/test/main_unit_test_serialization.c
@@ -198,11 +198,10 @@ static void test_spatial_calls_decline(Bmi *model) {
     printf("   all four decline both calls\n");
 }
 
-/* TODO: hotstart is the only restore supported at present; a full resume,
-   continuing the same simulation, will need its own coverage here. */
-
-/* A restore is a hotstart: physical state carries over, while the clock and the
-   run integrals stay with the run that is doing the restoring. */
+/* TODO: hotstart is the only restore driven at present; a full resume,
+   continuing the same simulation, will need its own coverage here.
+   A restore applies every archived value except the clock, which stays with the
+   run doing the restoring. */
 static void test_round_trip(void) {
     printf("\n[6] Save, diverge, restore\n");
     Bmi *model = make_model();
@@ -210,7 +209,7 @@ static void test_round_trip(void) {
 
     topmodel_model *m = (topmodel_model *)model->data;
     int saved_step = m->current_time_step;
-    double saved_sbar = m->sbar, saved_sumq = m->sumq;
+    double saved_sbar = m->sbar, saved_sumq = m->sumq, saved_sump = m->sump;
     double saved_deficit = m->deficit_local[0];
 
     char *payload = NULL;
@@ -225,20 +224,19 @@ static void test_round_trip(void) {
     step(model, 3);
     CHECK(m->current_time_step != saved_step, "model did not advance after capture");
     int diverged_step = m->current_time_step;
-    double diverged_sumq = m->sumq, diverged_sump = m->sump;
 
     CHECK(model->set_value(model, "ngen::serialization_state", payload) == BMI_SUCCESS,
           "restore failed");
 
     CHECK(m->sbar == saved_sbar, "sbar = %g, expected %g", m->sbar, saved_sbar);
+    CHECK(m->sumq == saved_sumq, "sumq = %g, expected %g", m->sumq, saved_sumq);
+    CHECK(m->sump == saved_sump, "sump = %g, expected %g", m->sump, saved_sump);
     CHECK(m->deficit_local[0] == saved_deficit,
           "deficit_local[0] = %g, expected %g", m->deficit_local[0], saved_deficit);
 
     CHECK(m->current_time_step == diverged_step,
           "restore moved the clock to %d; a hotstart keeps its own", m->current_time_step);
-    CHECK(m->sumq == diverged_sumq && m->sump == diverged_sump,
-          "restore replaced the run integrals; a hotstart keeps its own");
-    printf("   physical state restored, clock left at step %d\n", m->current_time_step);
+    printf("   state restored, clock left at step %d\n", m->current_time_step);
 
     free(payload);
     destroy_model(model);
@@ -249,7 +247,7 @@ static void test_restore_matches_uninterrupted(void) {
     Bmi *reference = make_model();
     step(reference, 7);
     topmodel_model *r = (topmodel_model *)reference->data;
-    double ref_sbar = r->sbar, ref_Qout = r->Qout;
+    double ref_sbar = r->sbar, ref_sumq = r->sumq, ref_Qout = r->Qout;
 
     Bmi *interrupted = make_model();
     step(interrupted, 4);
@@ -266,12 +264,11 @@ static void test_restore_matches_uninterrupted(void) {
           "restore failed");
     step_range(interrupted, 4, 7);
 
-    // TODO: hotstart is the only restore supported at present; a full resume,
-    // continuing the same simulation, will need its own coverage here.
     topmodel_model *n = (topmodel_model *)interrupted->data;
     CHECK(n->sbar == ref_sbar, "sbar = %g, uninterrupted gave %g", n->sbar, ref_sbar);
+    CHECK(n->sumq == ref_sumq, "sumq = %g, uninterrupted gave %g", n->sumq, ref_sumq);
     CHECK(n->Qout == ref_Qout, "Qout = %g, uninterrupted gave %g", n->Qout, ref_Qout);
-    printf("   sbar=%g Qout=%g in both runs\n", n->sbar, n->Qout);
+    printf("   sbar=%g sumq=%g Qout=%g in both runs\n", n->sbar, n->sumq, n->Qout);
 
     free(payload);
     destroy_model(reference);
@@ -358,16 +355,16 @@ static void test_rejects_bad_payloads(void) {
     destroy_model(model);
 }
 
-/* The mode is fixed at hotstart today, so this covers the other branch of the
-   restore and keeps it from quietly becoming dead code. */
-static void test_resume_mode_applies_run_state(void) {
-    printf("\n[10] Resume mode applies the clock and run integrals\n");
+/* The clock is the only field the mode discriminates, and the mode is fixed at
+   hotstart today, so this covers the other branch and keeps it from quietly
+   becoming dead code. */
+static void test_resume_mode_applies_the_clock(void) {
+    printf("\n[10] Resume mode takes the clock from the snapshot\n");
     Bmi *model = make_model();
     step(model, 4);
 
     topmodel_model *m = (topmodel_model *)model->data;
     int saved_step = m->current_time_step;
-    double saved_sumq = m->sumq;
 
     char *payload = NULL;
     int payload_size = 0;
@@ -383,8 +380,7 @@ static void test_resume_mode_applies_run_state(void) {
           "restore failed");
     CHECK(m->current_time_step == saved_step,
           "current_time_step = %d, expected the snapshot's %d", m->current_time_step, saved_step);
-    CHECK(m->sumq == saved_sumq, "sumq = %g, expected the snapshot's %g", m->sumq, saved_sumq);
-    printf("   clock and integrals taken from the snapshot at step %d\n", m->current_time_step);
+    printf("   clock taken from the snapshot at step %d\n", m->current_time_step);
 
     free(payload);
     destroy_model(model);
@@ -411,7 +407,7 @@ int main(void) {
     test_restore_matches_uninterrupted();
     test_free_is_safe();
     test_rejects_bad_payloads();
-    test_resume_mode_applies_run_state();
+    test_resume_mode_applies_the_clock();
 
     printf("\n***************************************\n");
     if (failures == 0) {


### PR DESCRIPTION
Implements the (pending) [ngen BMI serialization protocol](https://github.com/NOAA-OWP/ngen/pull/957).  Initial implementation geared primarily to supporting _hotstart_ scenarios that should not restore full state (i.e., _resume_ restores of full checkpoints).  Designed to prepare for future use of _resume_ restores as well, once mechanism is in place to communicate to model which is in use.

Builds on the earlier NGWPC serialization work, present in the NGWPC/development branch, while adapting it for aforementiion ngen protocol.  In particular, adheres to the same set of properties being serialized and deserialized as in the NGWPC version, excepted for deseiralization of `current_time_step` (left out of restore because its wrong for _hotstart_).

Note that it is likely other state properties should also be omitted from _hotstart_ restore deserialization.  However, that will be scoped to a different issue/PR; this is just for the initial functional port of serialization functionality compatible with the ngen protocol.

## Additions

- `src/bmi_serialization.cpp`, `include/bmi_serialization.h`, with Boost-based binary serialize/deserialize of model state, with support for stale payloads checks.
- `include/ngen_utilities.h`, with details on the protocol's four reserved variable names and their required units, types and item sizes.
- `include/vecbuf.hpp`, with vendored streambuf adapters to optimize archive reads/writes.
- `test/main_unit_test_serialization.c`, with protocol conformance and round trip tests
- `test/main_integration_test_serialization.c`, with 950 time step restart equivalence integration test.
- define deserialization restore types for future use
- CMake targets for test suites, with AddressSanitizer on by default for tests.

## Removals

-

## Changes

- `Get_value`/`Set_value` and other appropriate BMI functions to support variables for protocol and through those trigger serialization and deserialization
- Restore supporting different variations depending on restore mode, though just defaulting to _hotstart_  for now
- Moving the project to C++ 17
- Requiring Boost 1.86.0 serialization as project dependency

## Testing

1. `cmake -B build && cmake --build build`
2. Run from the build directory:  the `.run` config names its inputs relative to cwd: `cd build`
3. `./serialization_unit_tests`:  10 checks, all passing
4. `./serialization_integration_tests`:  3 scenarios over 950 steps and 14 variables, all passing
5. `./simple_unit_tests`:  existing suite, unaffected


## Screenshots


## Notes

- New external Boost::serialization dependency is not header-only

## Todos

- Establish way of determining/communicating/receiving which restore method should apply
- `current_time_step` is read by the physics (channel routing), not only used as an index; it thus both clearly meets the criteria to be excluded AND clearly meets the criteria to be included in the state transferred in a _hotstart_ restore (probably this means state needs to be extended, as this property is overloaded)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux